### PR TITLE
updated slog-scope and slog-stdlog version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ serde_derive = "1"
 slog = "2"
 slog-async = "2"
 slog-term = "2"
-slog-scope = "3"
-slog-stdlog = "2"
+slog-scope = "4"
+slog-stdlog = "3"
 trackable = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
Now slog-scope 4.0.0 or lower  fails to compile with latest nightly compiler (rustc 1.24.0-nightly) .
See https://github.com/rust-lang/rust/issues/46738.
So its version should be updated.
And, thanks for nice library.