### PR TITLE
Add truncate method

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,7 @@ pub trait Config {
 /// type = "file"
 /// path = "/path/to/file.log"
 /// timezone = "utc"
+/// truncate = false
 /// "#;
 /// let _config: LoggerConfig = serdeconv::from_toml_str(toml).unwrap();
 /// # }

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,7 +72,6 @@ pub trait Config {
 /// type = "file"
 /// path = "/path/to/file.log"
 /// timezone = "utc"
-/// truncate = false
 /// "#;
 /// let _config: LoggerConfig = serdeconv::from_toml_str(toml).unwrap();
 /// # }

--- a/src/file.rs
+++ b/src/file.rs
@@ -61,8 +61,8 @@ impl FileLoggerBuilder {
         self
     }
 
-    /// By default, logger just appends the log messages to file.
-    /// If this method called, when opening the file logger truncate it to 0 length.
+    /// By default, logger just appends log messages to file.
+    /// If this method called, logger truncates the file to 0 length when opening.
     pub fn truncate(&mut self) -> &mut Self {
         self.appender.truncate = true;
         self
@@ -181,6 +181,7 @@ pub struct FileLoggerConfig {
     pub channel_size: usize,
 
     /// Truncate the file or not
+    #[serde(default)]
     pub truncate: bool,
 }
 impl Config for FileLoggerConfig {


### PR DESCRIPTION
Added 'truncate method' to FileLoggerBuilder.
If this method called, logger truncates the file to 0 length when opening it.
This commit doesn't cause compile error in existing code, unless it constructs FileLoggerConfig directly in C struct style(like FileLoggerConfig{level: Trace,...}).
Though this library seems to be aiming for simplicity, I think this method is useful.