### PR TITLE
Add source_location parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 target/
 **/*.rs.bk
 Cargo.lock

--- a/examples/conf/file.toml
+++ b/examples/conf/file.toml
@@ -1,5 +1,6 @@
-type = "file"
-format = "full"
-timezone = "local"
-level = "debug"
+type = "file" # terminal or file
+format = "full" # full or compact
+source_location = "module_and_line" # none or module_and_line
+timezone = "local" # utc or local
+level = "debug" # one of trace, debug, info, warning, error, critical
 path = "file.log"

--- a/examples/conf/terminal.toml
+++ b/examples/conf/terminal.toml
@@ -1,5 +1,6 @@
-type = "terminal"
-format = "full"
-timezone = "utc"
-destination = "stderr"
-level = "debug"
+type = "terminal" # terminal or file
+format = "full" # full or compact
+source_location = "module_and_line" # none or module_and_line
+timezone = "utc" # utc or local
+level = "debug" # one of trace, debug, info, warning, error, critical
+destination = "stderr" # stderr or stdout

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,7 @@ pub trait Config {
 /// extern crate sloggers;
 /// extern crate serdeconv;
 ///
-/// use sloggers::{Config, LoggerConfig};
+/// use sloggers::LoggerConfig;
 ///
 /// # fn main() {
 /// let toml = r#"
@@ -48,7 +48,7 @@ pub trait Config {
 /// extern crate sloggers;
 /// extern crate serdeconv;
 ///
-/// use sloggers::{Config, LoggerConfig};
+/// use sloggers::LoggerConfig;
 ///
 /// # fn main() {
 /// let toml = r#"
@@ -65,7 +65,7 @@ pub trait Config {
 /// extern crate sloggers;
 /// extern crate serdeconv;
 ///
-/// use sloggers::{Config, LoggerConfig};
+/// use sloggers::LoggerConfig;
 ///
 /// # fn main() {
 /// let toml = r#"

--- a/src/types.rs
+++ b/src/types.rs
@@ -133,3 +133,39 @@ impl FromStr for TimeZone {
         }
     }
 }
+
+/// SourceLocation
+///
+/// # Examples
+///
+/// The default value:
+///
+/// ```
+/// use sloggers::types::SourceLocation;
+///
+/// assert_eq!(SourceLocation::default(), SourceLocation::ModuleAndLine);
+/// ```
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceLocation {
+    None,
+    ModuleAndLine,
+}
+
+impl Default for SourceLocation {
+    fn default() -> Self {
+        SourceLocation::ModuleAndLine
+    }
+}
+
+impl FromStr for SourceLocation {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "none" => Ok(SourceLocation::None),
+            "module_and_line" => Ok(SourceLocation::ModuleAndLine),
+            _ => track_panic!(ErrorKind::Invalid, "Undefined source code location: {:?}", s),
+        }
+    }
+}


### PR DESCRIPTION
This is my first pull request ever, so I hope I'm doing it right :)

This PR adds a new option for both the file and terminal logger configs, "source_location", which can either be `none` or `module_and_line`, being `module_and_line` by default to maintain backwards compatibility.

The intent is to add the possibility to remove source location logging, which I personally prefer to be off in production.

Along the way I've added comments to example config files and removed some doctest  warnings.