### PR TITLE
Add basic log file rotation functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ travis-ci = {repository = "sile/sloggers"}
 codecov = {repository = "sile/sloggers"}
 
 [dependencies]
+libflate = "0.1"
 serde = "1"
 serde_derive = "1"
 slog = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sloggers"
-version = "0.2.9-SNAPSHOT"
+version = "0.2.8"
 authors = ["Takeru Ohta <phjgt308@gmail.com>"]
 description = "This library provides frequently used slog loggers and convenient functions"
 homepage = "https://github.com/sile/sloggers"
@@ -14,7 +14,7 @@ travis-ci = {repository = "sile/sloggers"}
 codecov = {repository = "sile/sloggers"}
 
 [dependencies]
-chrono="0"
+chrono="0.4"
 serde = "1"
 serde_derive = "1"
 slog = "2"
@@ -23,8 +23,9 @@ slog-term = "2"
 slog-scope = "4"
 slog-kvfilter = "~0.6"
 slog-stdlog = "3"
-trackable = "0.2"
+trackable = "0.2.19"
 
 [dev-dependencies]
 clap = "2"
 serdeconv = "0.3"
+tempdir = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ trackable = "0.2"
 [dev-dependencies]
 clap = "2"
 serdeconv = "0.3"
+tempdir = "0.3"

--- a/examples/conf/file.toml
+++ b/examples/conf/file.toml
@@ -6,3 +6,4 @@ level = "debug" # one of trace, debug, info, warning, error, critical
 path = "file.log"
 rotate_size = 256
 rotate_keep = 2
+# rotate_compress = true

--- a/examples/conf/file.toml
+++ b/examples/conf/file.toml
@@ -4,3 +4,5 @@ source_location = "module_and_line" # none or module_and_line
 timezone = "local" # utc or local
 level = "debug" # one of trace, debug, info, warning, error, critical
 path = "file.log"
+rotate_size = 256
+rotate_keep = 2

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,9 +3,8 @@ use trackable::error::TrackableError;
 use trackable::error::{ErrorKind as TrackableErrorKind, ErrorKindExt};
 
 /// The error type for this crate.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, TrackableError)]
 pub struct Error(TrackableError<ErrorKind>);
-derive_traits_for_trackable_error_newtype!(Error, ErrorKind);
 impl From<io::Error> for Error {
     fn from(f: io::Error) -> Self {
         ErrorKind::Other.cause(f).into()

--- a/src/file.rs
+++ b/src/file.rs
@@ -97,9 +97,18 @@ impl FileLoggerBuilder {
         self
     }
 
-    /// TODO: doc
+    /// Sets the threshold used for determining whether rotate the current log file.
+    ///
+    /// If the byte size of the current log file exceeds this value, the file will be rotated.
+    /// The name of the rotated file will be `"${ORIGINAL_FILE_NAME}.0"`.
+    /// If there is a previously rotated file,
+    /// it will be renamed to `"${ORIGINAL_FILE_NAME}.1"` before rotation of the current log file.
+    /// This process is iterated recursively until log file names no longer conflict or
+    /// [`rotate_keep`] limit reached.
     ///
     /// The default value is `std::u64::MAX`.
+    ///
+    /// [`rotate_keep`]: ./struct.FileLoggerBuilder.html#method.rotate_keep
     pub fn rotate_size(&mut self, size: u64) -> &mut Self {
         self.appender.rotate_size = size;
         self
@@ -107,7 +116,7 @@ impl FileLoggerBuilder {
 
     /// Sets the maximum number of rotated log files to keep.
     ///
-    /// Older rotated log files get pruned.
+    /// If the number of rotated log files exceed this value, the oldest log file will be deleted.
     ///
     /// The default value is `8`.
     pub fn rotate_keep(&mut self, count: usize) -> &mut Self {

--- a/src/file.rs
+++ b/src/file.rs
@@ -110,7 +110,7 @@ impl FileLoggerBuilder {
     /// Older rotated log files get pruned.
     ///
     /// The default value is `8`.
-    pub fn rotate_keep(&mut self, count: u64) -> &mut Self {
+    pub fn rotate_keep(&mut self, count: usize) -> &mut Self {
         self.appender.rotate_keep = count;
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,8 @@ extern crate slog_kvfilter;
 extern crate slog_scope;
 extern crate slog_stdlog;
 extern crate slog_term;
+#[cfg(test)]
+extern crate tempdir;
 #[macro_use]
 extern crate trackable;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@
 //! # }
 //! ```
 #![warn(missing_docs)]
+extern crate libflate;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@ extern crate slog_kvfilter;
 extern crate slog_scope;
 extern crate slog_stdlog;
 extern crate slog_term;
+#[cfg(test)]
+extern crate tempdir;
 #[macro_use]
 extern crate trackable;
 


### PR DESCRIPTION
Add `rotate_size` and `rotate_keep` options to `FileLoggerBuilder` and `FileLoggerConfig` for supporting basic log file rotation.

Related Issue: https://github.com/sile/sloggers/issues/12