### PR TITLE
Implement #7: Timestamp in log file name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sloggers"
-version = "0.2.8"
+version = "0.2.9-SNAPSHOT"
 authors = ["Takeru Ohta <phjgt308@gmail.com>"]
 description = "This library provides frequently used slog loggers and convenient functions"
 homepage = "https://github.com/sile/sloggers"
@@ -14,6 +14,7 @@ travis-ci = {repository = "sile/sloggers"}
 codecov = {repository = "sile/sloggers"}
 
 [dependencies]
+chrono="0"
 serde = "1"
 serde_derive = "1"
 slog = "2"

--- a/examples/conf/file.toml
+++ b/examples/conf/file.toml
@@ -3,4 +3,12 @@ format = "full" # full or compact
 source_location = "module_and_line" # none or module_and_line
 timezone = "local" # utc or local
 level = "debug" # one of trace, debug, info, warning, error, critical
-path = "file.log"
+
+# {timestamp} will be replaced with timestamp in the appropriate time zone
+# formatted according to the timestamp_template setting.
+path = "file_{timestamp}.log"
+
+# Format string for the timestamp in path.
+# The string is formatted using [strftime](https://docs.rs/chrono/0.4.6/chrono/format/strftime/index.html#specifiers)
+# Default: "%Y%m%d_%H%M", example: "20180918_1127"
+timestamp_template = "%Y%m%d_%H%M"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@
 //! # }
 //! ```
 #![warn(missing_docs)]
+
+extern crate chrono;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
Relevant configuration in `file.toml`:

```toml
# ...
timezone = "local" # utc or local

# {timestamp} will be replaced with timestamp in the appropriate time zone
# formatted according to the timestamp_template setting.
path = "file_{timestamp}.log"

# Format string for the timestamp in path.
# The string is formatted using [strftime](https://docs.rs/chrono/0.4.6/chrono/format/strftime/index.html#specifiers)
# Default: "%Y%m%d_%H%M", example: "20180918_1127"
timestamp_template = "%Y%m%d_%H%M"
```