### PR TITLE
Add more ways to display module information

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -205,6 +205,9 @@ impl FileLoggerBuilder {
             SourceLocation::FileAndLine => {
                 Logger::root(drain.fuse(), o!("module" => FnValue(misc::file_and_line)))
             }
+            SourceLocation::LocalFileAndLine => {
+                Logger::root(drain.fuse(), o!("module" => FnValue(misc::local_file_and_line)))
+            }
         }
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,5 +1,5 @@
 //! File logger.
-use crate::misc::{module_and_line, timezone_to_timestamp_fn};
+use crate::misc;
 #[cfg(feature = "slog-kvfilter")]
 use crate::types::KVFilterParameters;
 use crate::types::{Format, OverflowStrategy, Severity, SourceLocation, TimeZone};
@@ -200,7 +200,10 @@ impl FileLoggerBuilder {
         match self.source_location {
             SourceLocation::None => Logger::root(drain.fuse(), o!()),
             SourceLocation::ModuleAndLine => {
-                Logger::root(drain.fuse(), o!("module" => FnValue(module_and_line)))
+                Logger::root(drain.fuse(), o!("module" => FnValue(misc::module_and_line)))
+            }
+            SourceLocation::FileAndLine => {
+                Logger::root(drain.fuse(), o!("module" => FnValue(misc::file_and_line)))
             }
         }
     }
@@ -209,7 +212,7 @@ impl FileLoggerBuilder {
 impl Build for FileLoggerBuilder {
     fn build(&self) -> Result<Logger> {
         let decorator = PlainDecorator::new(self.appender.clone());
-        let timestamp = timezone_to_timestamp_fn(self.timezone);
+        let timestamp = misc::timezone_to_timestamp_fn(self.timezone);
         let logger = match self.format {
             Format::Full => {
                 let format = FullFormat::new(decorator).use_custom_timestamp(timestamp);

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -17,6 +17,10 @@ pub fn module_and_line(record: &Record) -> String {
     format!("{}:{}", record.module(), record.line())
 }
 
+pub fn file_and_line(record: &Record) -> String {
+    format!("{}:{}", record.file(), record.line())
+}
+
 pub fn timezone_to_timestamp_fn(timezone: TimeZone) -> fn(&mut dyn io::Write) -> io::Result<()> {
     match timezone {
         TimeZone::Utc => slog_term::timestamp_utc,

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -5,6 +5,7 @@ use slog_scope;
 use slog_stdlog;
 use slog_term;
 use std::io;
+use std::path::Path;
 use trackable::error::ErrorKindExt;
 
 /// Sets the logger for the log records emitted via `log` crate.
@@ -19,6 +20,15 @@ pub fn module_and_line(record: &Record) -> String {
 
 pub fn file_and_line(record: &Record) -> String {
     format!("{}:{}", record.file(), record.line())
+}
+
+pub fn local_file_and_line(record: &Record) -> String {
+    if Path::new(record.file()).is_relative() {
+        file_and_line(record)
+    } else {
+        module_and_line(record)
+    }
+
 }
 
 pub fn timezone_to_timestamp_fn(timezone: TimeZone) -> fn(&mut dyn io::Write) -> io::Result<()> {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,5 +1,5 @@
 //! Terminal logger.
-use crate::misc::{module_and_line, timezone_to_timestamp_fn};
+use crate::misc;
 #[cfg(feature = "slog-kvfilter")]
 use crate::types::KVFilterParameters;
 use crate::types::{Format, OverflowStrategy, Severity, SourceLocation, TimeZone};
@@ -145,7 +145,10 @@ impl TerminalLoggerBuilder {
         match self.source_location {
             SourceLocation::None => Logger::root(drain.fuse(), o!()),
             SourceLocation::ModuleAndLine => {
-                Logger::root(drain.fuse(), o!("module" => FnValue(module_and_line)))
+                Logger::root(drain.fuse(), o!("module" => FnValue(misc::module_and_line)))
+            }
+            SourceLocation::FileAndLine => {
+                Logger::root(drain.fuse(), o!("module" => FnValue(misc::file_and_line)))
             }
         }
     }
@@ -158,7 +161,7 @@ impl Default for TerminalLoggerBuilder {
 impl Build for TerminalLoggerBuilder {
     fn build(&self) -> Result<Logger> {
         let decorator = self.destination.to_decorator();
-        let timestamp = timezone_to_timestamp_fn(self.timezone);
+        let timestamp = misc::timezone_to_timestamp_fn(self.timezone);
         let logger = match self.format {
             Format::Full => {
                 let format = FullFormat::new(decorator).use_custom_timestamp(timestamp);

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -150,6 +150,9 @@ impl TerminalLoggerBuilder {
             SourceLocation::FileAndLine => {
                 Logger::root(drain.fuse(), o!("module" => FnValue(misc::file_and_line)))
             }
+            SourceLocation::LocalFileAndLine => {
+                Logger::root(drain.fuse(), o!("module" => FnValue(misc::local_file_and_line)))
+            }
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -205,6 +205,7 @@ pub enum SourceLocation {
     None,
     ModuleAndLine,
     FileAndLine,
+    LocalFileAndLine,
 }
 impl Default for SourceLocation {
     fn default() -> Self {
@@ -218,6 +219,7 @@ impl FromStr for SourceLocation {
             "none" => Ok(SourceLocation::None),
             "module_and_line" => Ok(SourceLocation::ModuleAndLine),
             "file_and_line" => Ok(SourceLocation::FileAndLine),
+            "local_file_and_line" => Ok(SourceLocation::LocalFileAndLine),
             _ => track_panic!(
                 ErrorKind::Invalid,
                 "Undefined source code location: {:?}",

--- a/src/types.rs
+++ b/src/types.rs
@@ -204,6 +204,7 @@ impl FromStr for TimeZone {
 pub enum SourceLocation {
     None,
     ModuleAndLine,
+    FileAndLine,
 }
 impl Default for SourceLocation {
     fn default() -> Self {
@@ -216,6 +217,7 @@ impl FromStr for SourceLocation {
         match s {
             "none" => Ok(SourceLocation::None),
             "module_and_line" => Ok(SourceLocation::ModuleAndLine),
+            "file_and_line" => Ok(SourceLocation::FileAndLine),
             _ => track_panic!(
                 ErrorKind::Invalid,
                 "Undefined source code location: {:?}",


### PR DESCRIPTION
This PR adds some more ways to output log invocation site.

I would not recommend this for usage in releases, but for local development it's very handy to be able to use something like VSCode ctrl clicking on file:line to go to that location in file.

## FileAndLine

Produces

```text
"module" => "/path/to/bla/that/may/be/relative/or/not.rs:7"
```

## LocalFileAndLine

This produces for logs where `std::file!()` reported with a relative
path, e.g when log is made by workspace member

```text
"module" => "my_crate/src/lib.rs:42"
```

and else

```text
"module" => "foo_crate::module::bar:101"
```

## Note

One thing to think about is if still calling it module is appropriate, maybe calling the key "file" is more appropriate?
