### PR TITLE
Make various items `#[non_exhaustive]`

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -13,6 +13,7 @@ pub trait Build {
 /// Logger builder.
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
+#[non_exhaustive]
 pub enum LoggerBuilder {
     /// File logger.
     File(FileLoggerBuilder),

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,6 +74,7 @@ pub trait Config {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum LoggerConfig {
     File(FileLoggerConfig),
     Null(NullLoggerConfig),

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,7 @@ impl From<io::Error> for Error {
 
 /// A list of error kinds.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ErrorKind {
     /// Invalid input.
     Invalid,

--- a/src/file.rs
+++ b/src/file.rs
@@ -459,6 +459,7 @@ impl Write for FileAppender {
 
 /// The configuration of `FileLoggerBuilder`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct FileLoggerConfig {
     /// Log level.
     #[serde(default)]
@@ -533,6 +534,13 @@ pub struct FileLoggerConfig {
     /// The default value is `drop_and_report`.
     #[serde(default)]
     pub overflow_strategy: OverflowStrategy,
+}
+
+impl FileLoggerConfig {
+    /// Creates a new `FileLoggerConfig` with default settings.
+    pub fn new() -> Self {
+        Default::default()
+    }
 }
 
 impl Config for FileLoggerConfig {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -246,6 +246,7 @@ impl slog_term::Decorator for Decorator {
 
 /// The configuration of `TerminalLoggerBuilder`.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct TerminalLoggerConfig {
     /// Log level.
     #[serde(default)]
@@ -278,6 +279,12 @@ pub struct TerminalLoggerConfig {
     /// The default value is `drop_and_report`.
     #[serde(default)]
     pub overflow_strategy: OverflowStrategy,
+}
+impl TerminalLoggerConfig {
+    /// Creates a new `TerminalLoggerConfig` with default settings.
+    pub fn new() -> Self {
+        Default::default()
+    }
 }
 impl Config for TerminalLoggerConfig {
     type Builder = TerminalLoggerBuilder;

--- a/src/types.rs
+++ b/src/types.rs
@@ -94,9 +94,32 @@ impl FromStr for Severity {
 /// assert!(params.only_pass_on_regex.is_none());
 /// assert!(params.always_suppress_on_regex.is_none());
 /// ```
+/// 
+/// # Non-Exhaustive
+/// 
+/// This structure is marked [non-exhaustive]. It cannot be constructed using a `struct` expression:
+/// 
+/// ```compile_fail
+/// # use sloggers::types::{KVFilterParameters, Severity};
+/// let p = KVFilterParameters {
+///     severity: Severity::Warning,
+///     .. Default::default()
+/// };
+/// ```
+/// 
+/// Instead, use the `new` method to construct it, then fill the fields in:
+/// 
+/// ```
+/// # use sloggers::types::{KVFilterParameters, Severity};
+/// let mut p = KVFilterParameters::new();
+/// p.severity = Severity::Warning;
+/// ```
+/// 
+/// [non-exhaustive]: https://doc.rust-lang.org/stable/reference/attributes/type_system.html#the-non_exhaustive-attribute
 #[derive(Debug, Clone)]
 #[allow(missing_docs)]
 #[cfg(feature = "slog-kvfilter")]
+#[non_exhaustive]
 pub struct KVFilterParameters {
     pub severity: Severity,
     pub only_pass_any_on_all_keys: Option<KVFilterList>,
@@ -116,6 +139,14 @@ impl Default for KVFilterParameters {
         }
     }
 }
+#[cfg(feature = "slog-kvfilter")]
+impl KVFilterParameters {
+    /// Creates a new `KVFilterParameters` structure with default settings.
+    #[inline]
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
 
 /// The format of log records.
 ///
@@ -130,6 +161,7 @@ impl Default for KVFilterParameters {
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum Format {
     /// Full format.
     Full,
@@ -201,6 +233,7 @@ impl FromStr for TimeZone {
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum SourceLocation {
     None,
     ModuleAndLine,
@@ -243,6 +276,7 @@ impl FromStr for SourceLocation {
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum OverflowStrategy {
     DropAndReport,
     Drop,


### PR DESCRIPTION
Makes various items `#[non_exhaustive]`. Fixes #32.


Compatibility
=============

⚠ This is a breaking change. In particular, code that constructs a `FileLoggerConfig`, `TerminalLoggerConfig`, or `KVFilterParameters` will need to be changed to use the `new` method on these types.

⚠ This raises the minimum supported Rust version of this crate to [1.40], which is fairly recent (December 2019).


Changes Made
============

Items Made Non-Exhaustive
-------------------------

* `LoggerBuilder`, `LoggerConfig`

  This makes it non-breaking to add more logging destinations in the future.

* `ErrorKind`

  This makes it non-breaking to add more specific kinds of errors in the future.

* `file::FileLoggerConfig`, `terminal::TerminalLoggerConfig`

  This makes it non-breaking to add more configuration settings to these loggers (but see “Non-Exhaustive `struct`s” below).

* `types::KVFilterParameters`

  Made non-exhaustive because `slog_kvfilter::KVFilter` is effectively non-exhaustive (its fields are all private).

* `types::Format`, `types::SourceLocation`

  These could conceivably have more variants added at some point.

* `types::OverflowStrategy`

  Made non-exhaustive because [`slog_async::OverflowStrategy`] is non-exhaustive.


Items *Not* Made Non-Exhaustive
-------------------------------

* `null::NullLoggerBuilder`, `null::NullLoggerConfig`

  A logger that does nothing will probably never need configuration.

* `types::Severity`

  Not non-exhaustive because `slog::Level` is not non-exhaustive.

* `types::TimeZone`

  I'm not sure whether you intend to support using specific time zones (besides UTC and the local time zone) in the future, so I've left this one alone.


Non-Exhaustive `struct`s
========================

Note that marking a `struct` as non-exhaustive changes how to construct it. Instead of using the traditional `Struct { .. }` syntax, a constructor method must be used.

```rust
// This does not work.
let p = KVFilterParameters {
    severity: Severity::Trace,
    .. Default::default()
};

// This works.
let mut p = KVFilterParameters::new();
p.severity = Severity::Trace;
```

I've marked three `struct`s non-exhaustive: `FileLoggerConfig`, `TerminalLoggerConfig`, and `KVFilterParameters`. I've added a `new` method to each of them.

Rustdoc generates a short explanation of non-exhaustive `struct`s. I've added a longer explanation to the documentation for `KVFilterParameters`, since that one seems meant to be constructed by hand, whereas the other two seem meant to be constructed by serde.



[1.40]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1400-2019-12-19

[`slog_async::OverflowStrategy`]: https://docs.rs/slog-async/2/slog_async/enum.OverflowStrategy.html