### PR TITLE
Add syslog support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,7 @@ regex="1"
 clap = "2"
 serdeconv = "0.4"
 tempfile = "3"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+once_cell = "1"

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,6 +1,8 @@
 use crate::file::FileLoggerBuilder;
 use crate::misc;
 use crate::null::NullLoggerBuilder;
+#[cfg(unix)]
+use crate::syslog::SyslogBuilder;
 use crate::terminal::TerminalLoggerBuilder;
 #[cfg(feature = "slog-kvfilter")]
 use crate::types::KVFilterParameters;
@@ -30,6 +32,10 @@ pub enum LoggerBuilder {
     /// Null logger.
     Null(NullLoggerBuilder),
 
+    /// Syslog logger.
+    #[cfg(unix)]
+    Syslog(SyslogBuilder),
+
     /// Terminal logger.
     Terminal(TerminalLoggerBuilder),
 }
@@ -38,6 +44,8 @@ impl Build for LoggerBuilder {
         match *self {
             LoggerBuilder::File(ref b) => track!(b.build()),
             LoggerBuilder::Null(ref b) => track!(b.build()),
+            #[cfg(unix)]
+            LoggerBuilder::Syslog(ref b) => track!(b.build()),
             LoggerBuilder::Terminal(ref b) => track!(b.build()),
         }
     }

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,8 +1,17 @@
 use crate::file::FileLoggerBuilder;
+use crate::misc;
 use crate::null::NullLoggerBuilder;
 use crate::terminal::TerminalLoggerBuilder;
+#[cfg(feature = "slog-kvfilter")]
+use crate::types::KVFilterParameters;
+use crate::types::{OverflowStrategy, Severity, SourceLocation};
 use crate::Result;
-use slog::Logger;
+use slog::{Drain, FnValue, Logger};
+use slog_async::Async;
+#[cfg(feature = "slog-kvfilter")]
+use slog_kvfilter::KVFilter;
+use std::fmt::Debug;
+use std::panic::{RefUnwindSafe, UnwindSafe};
 
 /// This trait allows to build a logger instance.
 pub trait Build {
@@ -30,6 +39,84 @@ impl Build for LoggerBuilder {
             LoggerBuilder::File(ref b) => track!(b.build()),
             LoggerBuilder::Null(ref b) => track!(b.build()),
             LoggerBuilder::Terminal(ref b) => track!(b.build()),
+        }
+    }
+}
+
+/// Common code for wrapping up a bare `Drain` into a finished `Logger`.
+/// 
+/// This is just a data structure and a shared `build_with_drain` routine. Individual logger builders need to expose methods that fill in the fields of this `struct`, and their `Build` implementation needs to call `BuilderCommon::build_with_drain` after building the basic drain.
+#[derive(Debug)]
+pub(crate) struct BuilderCommon {
+    pub source_location: SourceLocation,
+    pub overflow_strategy: OverflowStrategy,
+    pub level: Severity,
+    pub channel_size: usize,
+    #[cfg(feature = "slog-kvfilter")]
+    pub kvfilterparameters: Option<KVFilterParameters>,
+}
+impl Default for BuilderCommon {
+    fn default() -> Self {
+        BuilderCommon {
+            source_location: SourceLocation::default(),
+            overflow_strategy: OverflowStrategy::default(),
+            level: Severity::default(),
+            channel_size: 1024,
+            #[cfg(feature = "slog-kvfilter")]
+            kvfilterparameters: None,
+        }
+    }
+}
+impl BuilderCommon {
+    pub fn build_with_drain<D>(&self, drain: D) -> Logger
+    where
+        D: Drain + Send + 'static,
+        D::Err: Debug,
+    {
+        // async inside, level and key value filters outside for speed
+        let drain = Async::new(drain.fuse())
+            .chan_size(self.channel_size)
+            .overflow_strategy(self.overflow_strategy.to_async_type())
+            .build()
+            .fuse();
+
+        #[cfg(feature = "slog-kvfilter")]
+        {
+            if let Some(ref p) = self.kvfilterparameters {
+                let kvdrain = KVFilter::new(drain, p.severity.as_level())
+                    .always_suppress_any(p.always_suppress_any.clone())
+                    .only_pass_any_on_all_keys(p.only_pass_any_on_all_keys.clone())
+                    .always_suppress_on_regex(p.always_suppress_on_regex.clone())
+                    .only_pass_on_regex(p.only_pass_on_regex.clone());
+                self.build_logger(kvdrain)
+            } else {
+                self.build_logger(drain)
+            }
+        }
+
+        #[cfg(not(feature = "slog-kvfilter"))]
+        self.build_logger(drain)
+    }
+
+    fn build_logger<D>(&self, drain: D) -> Logger
+    where
+        D: Drain + Send + Sync + UnwindSafe + RefUnwindSafe + 'static,
+        D::Err: Debug,
+    {
+        let drain = self.level.set_level_filter(drain.fuse());
+
+        match self.source_location {
+            SourceLocation::None => Logger::root(drain.fuse(), o!()),
+            SourceLocation::ModuleAndLine => {
+                Logger::root(drain.fuse(), o!("module" => FnValue(misc::module_and_line)))
+            }
+            SourceLocation::FileAndLine => {
+                Logger::root(drain.fuse(), o!("module" => FnValue(misc::file_and_line)))
+            }
+            SourceLocation::LocalFileAndLine => Logger::root(
+                drain.fuse(),
+                o!("module" => FnValue(misc::local_file_and_line)),
+            ),
         }
     }
 }

--- a/src/fake_syslog.rs
+++ b/src/fake_syslog.rs
@@ -1,0 +1,14 @@
+#![cfg(not(unix))]
+
+use serde::{de::Error, Deserialize, Deserializer, Serialize};
+
+/// Fake syslog configuration type, for platforms where syslog is not
+/// supported. Cannot be constructed.
+#[derive(Clone, Debug, Serialize)]
+pub enum SyslogNotSupported {}
+
+impl<'de> Deserialize<'de> for SyslogNotSupported {
+    fn deserialize<D: Deserializer<'de>>(_: D) -> Result<Self, D::Error> {
+        Err(D::Error::custom("syslog is not supported on this platform"))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,11 +55,13 @@ pub use misc::set_stdlog_logger;
 
 pub mod file;
 pub mod null;
+pub mod syslog;
 pub mod terminal;
 pub mod types;
 
 mod build;
 mod config;
+mod fake_syslog;
 mod error;
 mod misc;
 

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -1,0 +1,109 @@
+//! Logger that sends logs to local syslog daemon. Unix-like platforms only.
+//! Uses the [POSIX syslog API].
+//! 
+//! [POSIX syslog API]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/closelog.html
+//! 
+//! # Concurrency issues
+//! 
+//! POSIX doesn't support opening more than one connection to syslogd at a
+//! time. Although it is safe to construct more than one logger using this
+//! module at the same time, some of the settings for syslog loggers will be
+//! overwritten by the settings for additional syslog loggers created later.
+//! 
+//! For this reason, the following rules should be followed:
+//! 
+//! * Libraries should not use this module or otherwise call
+//!   `openlog` unless specifically told to do so by the main application.
+//! * An application that uses this module should not cause `openlog` to be
+//!   called from anywhere else.
+//! * An application should not use this module to construct more than one
+//!   `Logger` at the same time, except when constructing a new `Logger` that
+//!   is to replace an old one (for instance, if the application is reloading
+//!   its configuration files and reinitializing its logging pipeline).
+//! 
+//! Failure to abide by these rules may result in `closelog` being called at
+//! the wrong time. This will cause `openlog` settings (application name,
+//! syslog facility, and some flags) to be reset, and there may be a delay in
+//! processing the next log message after that (because the connection to the
+//! syslog server, if applicable, must be reopened).
+
+// TODO: Some systems (including OpenBSD and Android) have reentrant versions
+// of the POSIX syslog functions. These systems *do* support opening multiple
+// connections to syslog, and therefore do not suffer from the above
+// concurrency issues. Perhaps this crate should use the reentrant syslog API
+// on those platforms.
+
+// # Design and rationale
+// 
+// (This section is not part of the documentation for this module. It's only a
+// source code comment.)
+// 
+// This module uses the POSIX syslog API to submit log entries to the local
+// syslogd. This is unlike the `syslog` crate, which connects to `/dev/log` 
+// or `/var/run/log` directly. The reasons for this approach, despite the above
+// drawbacks, are as follows.
+// 
+// ## Portability
+// 
+// POSIX only specifies the `syslog` function and related functions.
+// 
+// POSIX does not specify that a Unix-domain socket is used for submitting log
+// messages to syslogd, nor the socket's path, nor the protocol used on that
+// socket. The path of the socket is different on different systems:
+// 
+// * `/dev/log` – original BSD, OpenBSD, Linux
+// * `/var/run/log` – FreeBSD and NetBSD (but on Linux with systemd, this
+//   is a folder)
+// * `/var/run/syslog` – Darwin/macOS
+// 
+// The protocol spoken on the socket is not formally specified. It is
+// whatever the system's `syslog` function writes to it, which may of course
+// vary between systems. It is typically different from IETF RFCs 3164 and
+// 5424.
+// 
+// The OpenBSD kernel has a dedicated system call for submitting log messages.
+// `/dev/log` is still available, but not preferred.
+// 
+// On macOS, the `syslog` function submits log entries to the Apple System Log
+// service. BSD-style log messages are accepted on `/var/run/syslog`, but that
+// is not preferred.
+// 
+// ## Reliability
+// 
+// On every platform that has a `syslog` function, it is battle-tested and
+// very definitely works.
+// 
+// ## Simplicity
+// 
+// Even in “classic” implementations of the POSIX `syslog` function, there are
+// a number of details that it keeps track of:
+// 
+// * Opening the socket
+// * Reopening the socket when necessary
+// * Formatting log messages for consumption by syslogd
+// * Determining the name of the process, when none is specified by the
+//   application
+// 
+// By calling the POSIX function, we avoid needing to reimplement all this in
+// Rust.
+
+#![cfg(unix)]
+
+mod builder;
+pub use builder::*;
+
+mod config;
+pub use config::*;
+
+mod drain;
+use drain::*;
+
+mod facility;
+pub use facility::*;
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+pub mod format;

--- a/src/syslog/builder.rs
+++ b/src/syslog/builder.rs
@@ -1,0 +1,369 @@
+use crate::Build;
+use crate::build::BuilderCommon;
+use crate::Result;
+use crate::types::{OverflowStrategy, Severity, SourceLocation};
+#[cfg(feature = "slog-kvfilter")]
+use crate::types::KVFilterParameters;
+use slog::Logger;
+use std::borrow::Cow;
+use std::ffi::{CStr, CString};
+use std::fmt::Debug;
+use std::sync::Arc;
+use super::{Facility, SyslogDrain};
+use super::format::{DefaultMsgFormat, MsgFormat};
+
+/// A logger builder which builds loggers that send log records to a syslog server.
+/// 
+/// All settings have sensible defaults. Simply calling
+/// `SyslogBuilder::new().build()` will yield a functional, reasonable
+/// `Logger` in most situations. However, most applications will want to set
+/// the `facility`.
+///
+/// The resulting logger will work asynchronously (the default channel size is 1024).
+/// 
+/// # Example
+/// 
+/// ```
+/// use slog::info;
+/// use sloggers::Build;
+/// use sloggers::types::Severity;
+/// use sloggers::syslog::{Facility, SyslogBuilder};
+/// use std::ffi::CStr;
+/// 
+/// # fn main() -> Result<(), sloggers::Error> {
+/// let logger = SyslogBuilder::new()
+///     .facility(Facility::User)
+///     .level(Severity::Debug)
+///     .ident(CStr::from_bytes_with_nul(b"sloggers-example-app\0").unwrap())
+///     .build()?;
+/// 
+/// info!(logger, "Hello, world! This is a test message from `sloggers::syslog`.");
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug)]
+pub struct SyslogBuilder {
+    pub(super) common: BuilderCommon,
+    pub(super) facility: Facility,
+    pub(super) ident: Option<Cow<'static, CStr>>,
+    pub(super) option: libc::c_int,
+    pub(super) format: Arc<dyn MsgFormat>,
+}
+
+impl Default for SyslogBuilder {
+    fn default() -> Self {
+        SyslogBuilder {
+            common: BuilderCommon::default(),
+            facility: Facility::default(),
+            ident: None,
+            option: 0,
+            format: Arc::new(DefaultMsgFormat),
+        }
+    }
+}
+
+impl SyslogBuilder {
+    /// Makes a new `SyslogBuilder` instance.
+    pub fn new() -> Self {
+        SyslogBuilder::default()
+    }
+
+    /// Sets the source code location type this logger will use.
+    pub fn source_location(&mut self, source_location: SourceLocation) -> &mut Self {
+        self.common.source_location = source_location;
+        self
+    }
+
+    /// Sets the syslog facility to send logs to.
+    /// 
+    /// By default, this is the `user` facility.
+    pub fn facility(&mut self, facility: Facility) -> &mut Self {
+        self.facility = facility;
+        self
+    }
+
+    /// Sets the overflow strategy for the logger.
+    pub fn overflow_strategy(&mut self, overflow_strategy: OverflowStrategy) -> &mut Self {
+        self.common.overflow_strategy = overflow_strategy;
+        self
+    }
+
+    /// Sets the name of this program, for inclusion with log messages.
+    /// (POSIX calls this the “tag”.)
+    /// 
+    /// The supplied string must not contain any zero (ASCII NUL) bytes.
+    /// 
+    /// # Default value
+    /// 
+    /// If a name is not given, the default behavior depends on the libc
+    /// implementation in use.
+    /// 
+    /// BSD, GNU, and Apple libc use the actual process name. µClibc uses the
+    /// constant string `syslog`. Fuchsia libc and musl libc use no name at
+    /// all.
+    /// 
+    /// # When to use
+    /// 
+    /// This method converts the given string to a C-compatible string at run
+    /// time. It should only be used if the process name is obtained
+    /// dynamically, such as from a configuration file.
+    /// 
+    /// If the process name is constant, use the `ident` method instead.
+    /// 
+    /// # Panics
+    /// 
+    /// This method panics if the supplied string contains any null bytes.
+    /// 
+    /// # Example
+    /// 
+    /// ```
+    /// use sloggers::Build;
+    /// use sloggers::syslog::SyslogBuilder;
+    /// 
+    /// # let some_string = "hello".to_string();
+    /// let my_ident: String = some_string;
+    /// 
+    /// let logger = SyslogBuilder::new()
+    ///     .ident_str(my_ident)
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    /// 
+    /// # Data use and lifetime
+    /// 
+    /// This method takes an ordinary Rust string, copies it into a
+    /// [`CString`] (which appends a null byte on the end), and passes that to
+    /// the `ident` method.
+    /// 
+    /// [`CString`]: https://doc.rust-lang.org/std/ffi/struct.CString.html
+    pub fn ident_str(&mut self, ident: impl AsRef<str>) -> &mut Self {
+        let cs = CString::new(ident.as_ref())
+            .expect("`sloggers::syslog::SyslogBuilder::ident` called with string that contains null bytes");
+
+        self.ident(cs)
+    }
+
+    /// Sets the name of this program, for inclusion with log messages.
+    /// (POSIX calls this the “tag”.)
+    /// 
+    /// # Default value
+    /// 
+    /// If a name is not given, the default behavior depends on the libc
+    /// implementation in use.
+    /// 
+    /// BSD, GNU, and Apple libc use the actual process name. µClibc uses the
+    /// constant string `syslog`. Fuchsia libc and musl libc use no name at
+    /// all.
+    /// 
+    /// # When to use
+    /// 
+    /// This method should be used if you already have a C-compatible string to
+    /// use for the process name, or if the process name is constant (as
+    /// opposed to taken from a configuration file or command line parameter).
+    /// 
+    /// # Data use and lifetime
+    /// 
+    /// This method takes a C-compatible string, either owned or with the
+    /// `'static` lifetime. This ensures that the string remains available for
+    /// the entire time that the system libc might need it (until `closelog` is
+    /// called, which happens when the built `Logger` is dropped).
+    /// 
+    /// # Example
+    /// 
+    /// ```
+    /// use sloggers::Build;
+    /// use sloggers::syslog::SyslogBuilder;
+    /// use std::ffi::CStr;
+    /// #
+    /// # assert_eq!(
+    /// #     CStr::from_bytes_with_nul("sloggers-example-app\0".as_bytes()).unwrap(),
+    /// #     std::ffi::CString::new("sloggers-example-app").unwrap().as_c_str()
+    /// # );
+    /// 
+    /// let logger = SyslogBuilder::new()
+    ///     .ident(CStr::from_bytes_with_nul("sloggers-example-app\0".as_bytes()).unwrap())
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn ident(&mut self, ident: impl Into<Cow<'static, CStr>>) -> &mut Self {
+        self.ident = Some(ident.into());
+        self
+    }
+
+    // The `log_*` flag methods are all `#[inline]` because, in theory, the
+    // optimizer could collapse several flag method calls into a single store
+    // operation, which would be much faster…but it can only do that if the
+    // calls are all inlined.
+
+    /// Include the process ID in log messages.
+    #[inline]
+    pub fn log_pid(&mut self) -> &mut Self {
+        self.option |= libc::LOG_PID;
+        self
+    }
+
+    /// Immediately open a connection to the syslog server, instead of waiting
+    /// until the first log message is sent.
+    /// 
+    /// `log_ndelay` and `log_odelay` are mutually exclusive, and one of them
+    /// is the default. Exactly which one is the default depends on the
+    /// platform, but on most platforms, `log_odelay` is the default.
+    /// 
+    /// On OpenBSD 5.6 and newer, this setting has no effect, because that
+    /// platform uses a dedicated system call instead of a socket for
+    /// submitting syslog messages.
+    #[inline]
+    pub fn log_ndelay(&mut self) -> &mut Self {
+        self.option = (self.option & !libc::LOG_ODELAY) | libc::LOG_NDELAY;
+        self
+    }
+
+    /// *Don't* immediately open a connection to the syslog server. Wait until
+    /// the first log message is sent before connecting.
+    /// 
+    /// `log_ndelay` and `log_odelay` are mutually exclusive, and one of them
+    /// is the default. Exactly which one is the default depends on the
+    /// platform, but on most platforms, `log_odelay` is the default.
+    /// 
+    /// On OpenBSD 5.6 and newer, this setting has no effect, because that
+    /// platform uses a dedicated system call instead of a socket for
+    /// submitting syslog messages.
+    #[inline]
+    pub fn log_odelay(&mut self) -> &mut Self {
+        self.option = (self.option & !libc::LOG_NDELAY) | libc::LOG_ODELAY;
+        self
+    }
+
+    /// If a child process is created to send a log message, don't wait for
+    /// that child process to exit.
+    /// 
+    /// This option is highly unlikely to have any effect on any modern system.
+    /// On a modern system, spawning a child process for every single log
+    /// message would be extremely slow. This option only ever existed as a
+    /// [workaround for limitations of the 2.11BSD kernel][2.11BSD wait call],
+    /// and was already [deprecated as of 4.4BSD][4.4BSD deprecation notice].
+    /// It is included here only for completeness because, unfortunately,
+    /// [POSIX defines it].
+    /// 
+    /// [2.11BSD wait call]: https://www.retro11.de/ouxr/211bsd/usr/src/lib/libc/gen/syslog.c.html#n:176
+    /// [4.4BSD deprecation notice]: https://github.com/sergev/4.4BSD-Lite2/blob/50587b00e922225c62f1706266587f435898126d/usr/src/sys/sys/syslog.h#L164
+    /// [POSIX defines it]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/closelog.html
+    #[inline]
+    pub fn log_nowait(&mut self) -> &mut Self {
+        self.option |= libc::LOG_NOWAIT;
+        self
+    }
+
+    /// Also emit log messages on `stderr` (**see warning**).
+    /// 
+    /// # Warning
+    /// 
+    /// The libc `syslog` function is not subject to the global mutex that
+    /// Rust uses to synchronize access to `stderr`. As a result, if one thread
+    /// writes to `stderr` at the same time as another thread emits a log
+    /// message with this option, the log message may appear in the middle of
+    /// the other thread's output.
+    /// 
+    /// Note that this problem is not specific to Rust or this crate. Any
+    /// program in any language that writes to `stderr` in one thread and logs
+    /// to `syslog` with `LOG_PERROR` in another thread at the same time will
+    /// have the same problem.
+    /// 
+    /// The exception is the `syslog` implementation in GNU libc, which
+    /// implements this option by writing to `stderr` through the C `stdio`
+    /// API (as opposed to the `write` system call), which has its own mutex.
+    /// As long as all threads write to `stderr` using the C `stdio` API, log
+    /// messages on this platform will never appear in the middle of other
+    /// `stderr` output. However, Rust does not use the C `stdio` API for
+    /// writing to `stderr`, so even on GNU libc, using this option may result 
+    /// in garbled output.
+    #[inline]
+    pub fn log_perror(&mut self) -> &mut Self {
+        self.option |= libc::LOG_PERROR;
+        self
+    }
+
+    /// Set a format for log messages and structured data.
+    /// 
+    /// The default is [`DefaultMsgFormat`].
+    /// 
+    /// This method wraps the format in an `Arc`. If your format is alrady
+    /// wrapped in an `Arc`, call the `format_arc` method instead.
+    /// 
+    /// # Example
+    /// 
+    /// ```
+    /// use sloggers::Build;
+    /// use sloggers::syslog::format::BasicMsgFormat;
+    /// use sloggers::syslog::SyslogBuilder;
+    /// 
+    /// let logger = SyslogBuilder::new()
+    ///     .format(BasicMsgFormat)
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    /// 
+    /// [`DefaultMsgFormat`]: format/struct.DefaultMsgFormat.html
+    pub fn format(&mut self, format: impl MsgFormat + 'static) -> &mut Self {
+        self.format_arc(Arc::new(format))
+    }
+
+    /// Set a custom format for log messages and structured data.
+    /// 
+    /// The default is [`DefaultMsgFormat`].
+    /// 
+    /// This method takes the format wrapped in an `Arc`. Call this if your
+    /// format is already wrapped in an `Arc`. If not, call the `format` method
+    /// instead.
+    /// 
+    /// # Example
+    /// 
+    /// ```
+    /// use sloggers::Build;
+    /// use sloggers::syslog::format::BasicMsgFormat;
+    /// use sloggers::syslog::SyslogBuilder;
+    /// use std::sync::Arc;
+    /// 
+    /// let format = Arc::new(BasicMsgFormat);
+    /// 
+    /// let logger = SyslogBuilder::new()
+    ///     .format_arc(format.clone())
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    /// 
+    /// [`DefaultMsgFormat`]: format/struct.DefaultMsgFormat.html
+    pub fn format_arc(&mut self, format: Arc<dyn MsgFormat>) -> &mut Self {
+        self.format = format;
+        self
+    }
+
+    /// Sets the log level of this logger.
+    pub fn level(&mut self, severity: Severity) -> &mut Self {
+        self.common.level = severity;
+        self
+    }
+
+    /// Sets the size of the asynchronous channel of this logger.
+    pub fn channel_size(&mut self, channel_size: usize) -> &mut Self {
+        self.common.channel_size = channel_size;
+        self
+    }
+
+    /// Sets [`KVFilter`].
+    ///
+    /// [`KVFilter`]: https://docs.rs/slog-kvfilter/0.6/slog_kvfilter/struct.KVFilter.html
+    #[cfg(feature = "slog-kvfilter")]
+    pub fn kvfilter(&mut self, parameters: KVFilterParameters) -> &mut Self {
+        self.common.kvfilterparameters = Some(parameters);
+        self
+    }
+}
+
+impl Build for SyslogBuilder {
+    fn build(&self) -> Result<Logger> {
+        let drain = SyslogDrain::new(self);
+        let logger = self.common.build_with_drain(drain);
+        Ok(logger)
+    }
+}

--- a/src/syslog/config.rs
+++ b/src/syslog/config.rs
@@ -1,0 +1,166 @@
+use crate::Config;
+use crate::types::{OverflowStrategy, Severity, SourceLocation};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::ffi::CStr;
+use super::{Facility, SyslogBuilder};
+use super::format::MsgFormatConfig;
+
+/// The configuration of `SyslogBuilder`.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+#[serde(default)]
+pub struct SyslogConfig {
+    /// Log level.
+    pub level: Severity,
+
+    /// How to format syslog messages with structured data.
+    /// 
+    /// Possible values are `default` and `basic`.
+    /// 
+    /// See [`MsgFormat`] for more information.
+    /// 
+    /// [`MsgFormat`]: format/trait.MsgFormat.html
+    pub format: MsgFormatConfig,
+
+    /// Source code location
+    pub source_location: SourceLocation,
+
+    /// The syslog facility to send logs to.
+    pub facility: Facility,
+
+    /// Asynchronous channel size
+    pub channel_size: usize,
+
+    /// Whether to drop logs on overflow.
+    ///
+    /// The possible values are `drop`, `drop_and_report`, or `block`.
+    ///
+    /// The default value is `drop_and_report`.
+    pub overflow_strategy: OverflowStrategy,
+
+    /// The name of this program, for inclusion with log messages. (POSIX calls
+    /// this the “tag”.)
+    /// 
+    /// The string must not contain any zero (ASCII NUL) bytes.
+    /// 
+    /// # Default value
+    /// 
+    /// If a name is not given, the default behavior depends on the libc
+    /// implementation in use.
+    /// 
+    /// BSD, GNU, and Apple libc use the actual process name. µClibc uses the
+    /// constant string `syslog`. Fuchsia libc and musl libc use no name at
+    /// all.
+    pub ident: Option<Cow<'static, CStr>>,
+
+    /// Include the process ID in log messages.
+    pub log_pid: bool,
+
+    /// Whether to immediately open a connection to the syslog server.
+    /// 
+    /// If true, a connection will be immediately opened. If false, the
+    /// connection will only be opened when the first log message is submitted.
+    /// 
+    /// The default is platform-defined, but on most platforms, the default is
+    /// `true`.
+    /// 
+    /// On OpenBSD 5.6 and newer, this setting has no effect, because that
+    /// platform uses a dedicated system call instead of a socket for
+    /// submitting syslog messages.
+    pub log_delay: Option<bool>,
+
+    /// Also emit log messages on `stderr` (**see warning**).
+    /// 
+    /// # Warning
+    /// 
+    /// The libc `syslog` function is not subject to the global mutex that
+    /// Rust uses to synchronize access to `stderr`. As a result, if one thread
+    /// writes to `stderr` at the same time as another thread emits a log
+    /// message with this option, the log message may appear in the middle of
+    /// the other thread's output.
+    /// 
+    /// Note that this problem is not specific to Rust or this crate. Any
+    /// program in any language that writes to `stderr` in one thread and logs
+    /// to `syslog` with `LOG_PERROR` in another thread at the same time will
+    /// have the same problem.
+    /// 
+    /// The exception is the `syslog` implementation in GNU libc, which
+    /// implements this option by writing to `stderr` through the C `stdio`
+    /// API (as opposed to the `write` system call), which has its own mutex.
+    /// As long as all threads write to `stderr` using the C `stdio` API, log
+    /// messages on this platform will never appear in the middle of other
+    /// `stderr` output. However, Rust does not use the C `stdio` API for
+    /// writing to `stderr`, so even on GNU libc, using this option may result 
+    /// in garbled output.
+    pub log_perror: bool,
+}
+
+impl SyslogConfig {
+    /// Creates a new `SyslogConfig` with default settings.
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+impl Default for SyslogConfig {
+    fn default() -> Self {
+        SyslogConfig {
+            level: Severity::default(),
+            format: MsgFormatConfig::default(),
+            source_location: SourceLocation::default(),
+            facility: Facility::default(),
+            channel_size: 1024,
+            overflow_strategy: OverflowStrategy::default(),
+            ident: None,
+            log_pid: false,
+            log_delay: None,
+            log_perror: false,
+        }
+    }
+}
+
+impl Config for SyslogConfig {
+    type Builder = SyslogBuilder;
+
+    fn try_to_builder(&self) -> crate::Result<Self::Builder> {
+        let mut b = SyslogBuilder::new();
+
+        b.level(self.level);
+        b.source_location(self.source_location);
+        b.facility(self.facility);
+        b.channel_size(self.channel_size);
+        b.overflow_strategy(self.overflow_strategy);
+
+        // Don't make this call if not using a non-default format, or there
+        // will be an unnecessary extra allocation. `SyslogBuilder::new`
+        // already allocates an `Arc<dyn MsgFormat>`, and this call allocates
+        // another one.
+        if self.format != MsgFormatConfig::Default {
+            b.format_arc((&self.format).into());
+        }
+
+        if let Some(ident) = &self.ident {
+            b.ident(ident.clone());
+        }
+
+        if self.log_pid {
+            b.log_pid();
+        }
+
+        if let Some(log_delay) = self.log_delay {
+            if log_delay {
+                b.log_odelay();
+            }
+            else {
+                b.log_ndelay();
+            }
+        }
+
+        if self.log_perror {
+            b.log_perror();
+        }
+
+        Ok(b)
+    }
+}

--- a/src/syslog/drain.rs
+++ b/src/syslog/drain.rs
@@ -1,0 +1,262 @@
+use libc::{c_char, c_int};
+use once_cell::sync::Lazy;
+use slog::{Drain, Level, Record, OwnedKVList};
+use std::borrow::Cow;
+use std::ffi::{CStr, CString};
+use std::ptr;
+use std::result::Result as StdResult;
+use std::sync::{Arc, Mutex, MutexGuard};
+use super::format::MsgFormat;
+use super::SyslogBuilder;
+
+#[cfg(not(test))]
+use libc::{closelog, openlog, syslog};
+#[cfg(test)]
+use super::mock::{self, closelog, openlog, syslog};
+
+/// Keeps track of which `ident` string was most recently passed to `openlog`.
+/// 
+/// The mutex is to be locked while calling `openlog` or `closelog`. It
+/// contains a possibly-null pointer to the `ident` string most recently passed
+/// to `openlog`, if that pointer came from `CStr::as_ptr`.
+/// 
+/// The pointer is stored as a `usize` because pointers are `!Send`. It is only
+/// used for comparison, never dereferenced.
+/// 
+/// # Purpose and rationale
+/// 
+/// The POSIX `openlog` function accepts a pointer to a C string. Though POSIX
+/// does not specify the expected lifetime of the string, all known
+/// implementations either
+/// 
+/// 1. keep the pointer in a global variable, or
+/// 2. copy the string into an internal buffer, which is kept in a global
+///    variable.
+/// 
+/// When running with an implementation in the second category, the string may
+/// be safely freed right away. When running with an implementation in the
+/// first category, however, the string must not be freed until either
+/// `closelog` is called or `openlog` is called with a *different, non-null*
+/// `ident`.
+/// 
+/// This mutex keeps track of which `ident` was most recently passed, making it
+/// possible to decide whether `closelog` needs to be called before a given
+/// `ident` string is dropped.
+/// 
+/// (Note: In the original 4.4BSD source code, the pointer is kept in a global
+/// variable, but `closelog` does *not* clear the pointer. In this case, it is
+/// only safe to free the string after `openlog` has been called with a
+/// different, non-null `ident`. Fortunately, all present-day implementations
+/// of `closelog` either clear the pointer or don't retain it at all.)
+static LAST_UNIQUE_IDENT: Lazy<Mutex<usize>> = Lazy::new(|| Mutex::new(ptr::null::<c_char>() as usize));
+
+pub(super) struct SyslogDrain {
+    /// The `ident` string, if it is owned by this `SyslogDrain`.
+    /// 
+    /// This is kept so that the string can be freed (and `closelog` called, if
+    /// necessary) when this `SyslogDrain` is dropped.
+    unique_ident: Option<Box<CStr>>,
+
+    /// The format for log messages.
+    format: Arc<dyn MsgFormat>,
+}
+
+impl SyslogDrain {
+    pub fn new(builder: &SyslogBuilder) -> Self {
+        // `ident` is the pointer that will be passed to `openlog`, maybe null.
+        // 
+        // `unique_ident` is the same pointer, wrapped in `Some` and `NonNull`,
+        // but only if the `ident` string provided by the application is owned.
+        // Otherwise it's `None`, indicating that `ident` either is null or
+        // points to a `&'static` string.
+        let (ident, unique_ident): (*const c_char, Option<Box<CStr>>) = match builder.ident.clone() {
+            Some(Cow::Owned(ident_s)) => {
+                let unique_ident = ident_s.into_boxed_c_str();
+
+                // Calling `NonNull:new_unchecked` is correct because
+                // `CString::into_raw` never returns a null pointer.
+                (unique_ident.as_ptr(), Some(unique_ident))
+            }
+            Some(Cow::Borrowed(ident_s)) => (ident_s.as_ptr(), None),
+            None => (ptr::null(), None),
+        };
+
+        {
+            // `openlog` and `closelog` are only called while holding the mutex
+            // around `last_unique_ident`.
+            let mut last_unique_ident: MutexGuard<usize> = LAST_UNIQUE_IDENT.lock().unwrap();
+
+            // Here, we call `openlog`. This has to happen *before* freeing the
+            // previous `ident` string, if applicable.
+            unsafe { openlog(ident, builder.option, builder.facility.into()); }
+
+            // If `openlog` is called with a null `ident` pointer, then the
+            // `ident` string passed to it previously will remain in use. But
+            // if the `ident` pointer is not null, then `last_unique_ident`
+            // needs updating.
+            if !ident.is_null() {
+                *last_unique_ident = match &unique_ident {
+                    // If the `ident` string is owned, store the pointer to it.
+                    Some(s) => s.as_ptr(),
+
+                    // If the `ident` string is not owned, set the stored
+                    // pointer to null.
+                    None => ptr::null::<c_char>(),
+                } as usize;
+            }
+        }
+
+        SyslogDrain {
+            unique_ident,
+            format: builder.format.clone(),
+        }
+    }
+}
+
+impl Drop for SyslogDrain {
+    fn drop(&mut self) {
+        // Check if this `SyslogDrain` was created with an owned `ident`
+        // string.
+        if let Some(my_ident) = self.unique_ident.take() {
+            // If so, then we need to check if that string is the one that
+            // was most recently passed to `openlog`.
+            let mut last_unique_ident: MutexGuard<usize> = match LAST_UNIQUE_IDENT.lock() {
+                Ok(locked) => locked,
+
+                // If the mutex was poisoned, then we'll just let the
+                // string leak.
+                // 
+                // There's no point in panicking here, and if there was a
+                // panic after `openlog` but before the pointer in the
+                // mutex was updated, then trying to free the pointed-to
+                // string may result in undefined behavior from a double
+                // free.
+                // 
+                // Thankfully, Rust's standard mutex implementation
+                // supports poisoning. Some alternative mutex
+                // implementations, such as in the `parking_lot` crate,
+                // don't support poisoning and would expose us to the
+                // aforementioned undefined behavior.
+                //
+                // It would be nice if we could un-poison a poisoned mutex,
+                // though. We have a perfectly good recovery strategy for
+                // that situation (resetting its pointer to null), but no way
+                // to use it.
+                Err(_) => {
+                    Box::leak(my_ident);
+                    return;
+                }
+            };
+
+            if my_ident.as_ptr() as usize == *last_unique_ident {
+                // Yes, the most recently used string was ours. We need to
+                // call `closelog` before our string is dropped.
+                //
+                // Note that this isn't completely free of races. It's still
+                // possible for some other code to call `openlog` independently
+                // of this module, after our `openlog` call. In that case, this
+                // `closelog` call will incorrectly close *that* logging handle
+                // instead of the one belonging to this `SyslogDrain`.
+                //
+                // Behavior in that case is still well-defined. Subsequent
+                // calls to `syslog` will implicitly reopen the logging handle
+                // anyway. The only problem is that the `openlog` options
+                // (facility, program name, etc) will all be reset. For this
+                // reason, it is a bad idea for a library to call `openlog` (or
+                // construct a `SyslogDrain`!) except when instructed to do so
+                // by the main program.
+                unsafe { closelog(); }
+
+                // Also, be sure to reset the pointer stored in the mutex.
+                // Although it is never dereferenced, letting it dangle may
+                // cause the above `if` to test true when it shouldn't, which
+                // would result in `closelog` being called when it shouldn't.
+                *last_unique_ident = ptr::null::<c_char>() as usize;
+            }
+
+            // When testing, before dropping the owned string, copy it into
+            // a mock event. We'll still drop it, though, in order to test for 
+            // double-free bugs.
+            #[cfg(test)]
+            mock::push_event(mock::Event::DropOwnedIdent(
+                String::from(my_ident.to_string_lossy())
+            ));
+
+            // Now that `closelog` has been called, it's safe for our string to
+            // be dropped, which will happen here.
+        }
+    }
+}
+
+impl Drain for SyslogDrain {
+    type Ok = ();
+    type Err = slog::Never;
+
+    fn log(&self, record: &Record, values: &OwnedKVList) -> StdResult<Self::Ok, Self::Err> {
+        // Format the message. If formatting fails, use an effectively null
+        // format (which shouldn't ever fail), and separately log the error.
+        let (msg, fmt_err) = match MsgFormat::to_string(self.format.as_ref(), record, values) {
+            Ok(msg) => (msg, None),
+            Err(fmt_err) => (record.msg().to_string(), Some(fmt_err.to_string())),
+        };
+
+        // Convert both strings to C strings.
+        let msg = to_cstring_lossy(msg);
+        let fmt_err = fmt_err.map(to_cstring_lossy);
+
+        // Figure out the priority.
+        let priority: c_int = match record.level() {
+            Level::Critical => libc::LOG_CRIT,
+            Level::Error => libc::LOG_ERR,
+            Level::Warning => libc::LOG_WARNING,
+            Level::Debug | Level::Trace => libc::LOG_DEBUG,
+
+            // `slog::Level` isn't non-exhaustive, so adding any more levels
+            // would be a breaking change. That is highly unlikely to ever
+            // happen. Still, we'll handle the possibility here, just in case.
+            _ => libc::LOG_INFO
+        };
+
+        // All set. Submit the log message.
+        unsafe {
+            syslog(
+                priority,
+                CStr::from_bytes_with_nul_unchecked(b"%s\0").as_ptr(),
+                msg.as_ptr()
+            );
+        }
+
+        // If there was a formatting error, log that too.
+        if let Some(fmt_err) = fmt_err {
+            unsafe {
+                syslog(
+                    libc::LOG_ERR,
+                    CStr::from_bytes_with_nul_unchecked(b"Error fully formatting the previous log message: %s\0").as_ptr(),
+                    fmt_err.as_ptr()
+                );
+            }
+        }
+
+        // Done.
+        Ok(())
+    }
+}
+
+/// Converts a `String` to a `CString`, stripping null bytes in the middle.
+/// 
+/// A null byte is added at the end if there isn't one already.
+/// 
+/// The difference between this and `CString::new` is that that method will
+/// fail if there are any null bytes instead of stripping them.
+fn to_cstring_lossy(s: String) -> CString {
+    // Get the bytes of the string.
+    let mut s: Vec<u8> = s.into();
+
+    // Strip any null bytes from the string.
+    s.retain(|b| *b != 0);
+
+    // This is sound because we just stripped all the null bytes from the
+    // input. Note that `CString::from_vec_unchecked` does add a null byte to
+    // the end of the input.
+    unsafe { CString::from_vec_unchecked(s) }
+}

--- a/src/syslog/facility.rs
+++ b/src/syslog/facility.rs
@@ -1,0 +1,453 @@
+use crate::error::{Error, ErrorKind};
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+use std::error::Error as StdError;
+use std::fmt::{self, Display};
+use std::result::Result as StdResult;
+use std::str::FromStr;
+use libc::c_int;
+
+/// A syslog facility. Conversions are provided to and from `c_int`.
+/// 
+/// Available facilities depend on the target platform. All variants of this
+/// `enum` are available on all platforms, and variants not present on the
+/// target platform will be mapped to a reasonable alternative.
+#[allow(missing_docs)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "lowercase")]
+pub enum Facility {
+    Auth,
+
+    /// Log messages containing sensitive information.
+    /// 
+    /// Available on: Linux, Emscripten, macOS, iOS, FreeBSD, DragonFly BSD,
+    /// OpenBSD, NetBSD
+    /// 
+    /// On other platforms: becomes `Auth`
+    AuthPriv,
+
+    /// Periodic task scheduling daemons like `cron`.
+    /// 
+    /// Available on: Linux, Emscripten, macOS, iOS, FreeBSD, DragonFly BSD,
+    /// OpenBSD, NetBSD, Solaris, illumos
+    /// 
+    /// On other platforms: becomes `Daemon`
+    Cron,
+
+    Daemon,
+
+    /// FTP server.
+    /// 
+    /// Available on: Linux, Emscripten, macOS, iOS, FreeBSD, DragonFly BSD,
+    /// OpenBSD, NetBSD
+    /// 
+    /// On other platforms: becomes `Daemon`
+    Ftp,
+
+    Kern,
+
+    /// macOS installer.
+    /// 
+    /// Available on: macOS, iOS
+    /// 
+    /// On other platforms: becomes `User`
+    Install,
+
+    /// `launchd`, the macOS process supervisor.
+    /// 
+    /// Available on: macOS, iOS
+    /// 
+    /// On other platforms: becomes `Daemon`
+    Launchd,
+
+    Local0,
+    Local1,
+    Local2,
+    Local3,
+    Local4,
+    Local5,
+    Local6,
+    Local7,
+    Lpr,
+    Mail,
+
+    /// Network Time Protocol daemon.
+    /// 
+    /// Available on: FreeBSD, DragonFly BSD
+    /// 
+    /// On other platforms: becomes `Daemon`
+    Ntp,
+
+    /// NeXT/early macOS `NetInfo` system.
+    /// 
+    /// Available on: macOS, iOS
+    /// 
+    /// On other platforms: becomes `Daemon`
+    NetInfo,
+
+    News,
+
+    /// macOS Remote Access Service.
+    /// 
+    /// Available on: macOS, iOS
+    /// 
+    /// On other platforms: becomes `User`
+    Ras,
+
+    /// macOS remote authentication and authorization.
+    /// 
+    /// Available on: macOS, iOS
+    /// 
+    /// On other platforms: becomes `Daemon`
+    RemoteAuth,
+
+    /// Security subsystems.
+    /// 
+    /// Available on: FreeBSD, DragonFly BSD
+    /// 
+    /// On other platforms: becomes `Auth`
+    Security,
+
+    Syslog,
+    User,
+    Uucp,
+}
+
+impl Facility {
+    /// Gets the name of this `Facility`, in lowercase.
+    /// 
+    /// The `FromStr` implementation accepts the same names, but it is
+    /// case-insensitive.
+    pub fn name(&self) -> &'static str {
+        match *self {
+            Facility::Auth       => "auth",
+            Facility::AuthPriv   => "authpriv",
+            Facility::Cron       => "cron",
+            Facility::Daemon     => "daemon",
+            Facility::Ftp        => "ftp",
+            Facility::Kern       => "kern",
+            Facility::Install    => "install",
+            Facility::Launchd    => "launchd",
+            Facility::Local0     => "local0",
+            Facility::Local1     => "local1",
+            Facility::Local2     => "local2",
+            Facility::Local3     => "local3",
+            Facility::Local4     => "local4",
+            Facility::Local5     => "local5",
+            Facility::Local6     => "local6",
+            Facility::Local7     => "local7",
+            Facility::Lpr        => "lpr",
+            Facility::Mail       => "mail",
+            Facility::Ntp        => "ntp",
+            Facility::NetInfo    => "netinfo",
+            Facility::News       => "news",
+            Facility::Ras        => "ras",
+            Facility::RemoteAuth => "remoteauth",
+            Facility::Security   => "security",
+            Facility::Syslog     => "syslog",
+            Facility::User       => "user",
+            Facility::Uucp       => "uucp",
+        }
+    }
+}
+
+impl Default for Facility {
+    fn default() -> Self {
+        Facility::User
+    }
+}
+
+impl Display for Facility {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+impl From<Facility> for c_int {
+    fn from(facility: Facility) -> Self {
+        match facility {
+            Facility::Auth => libc::LOG_AUTH,
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "macos",
+                target_os = "ios",
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "openbsd",
+                target_os = "netbsd",
+                target_env = "uclibc"
+            ))]
+            Facility::AuthPriv => libc::LOG_AUTHPRIV,
+            #[cfg(not(any(
+                target_os = "linux",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "macos",
+                target_os = "ios",
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "openbsd",
+                target_os = "netbsd",
+                target_env = "uclibc"
+            )))]
+            Facility::AuthPriv => libc::LOG_AUTH,
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "macos",
+                target_os = "ios",
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "openbsd",
+                target_os = "netbsd",
+                target_os = "solaris",
+                target_os = "illumos",
+                target_env = "uclibc"
+            ))]
+            Facility::Cron => libc::LOG_CRON,
+            #[cfg(not(any(
+                target_os = "linux",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "macos",
+                target_os = "ios",
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "openbsd",
+                target_os = "netbsd",
+                target_os = "solaris",
+                target_os = "illumos",
+                target_env = "uclibc"
+            )))]
+            Facility::Cron => libc::LOG_DAEMON,
+            Facility::Daemon => libc::LOG_DAEMON,
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "macos",
+                target_os = "ios",
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "openbsd",
+                target_os = "netbsd",
+                target_env = "uclibc"
+            ))]
+            Facility::Ftp => libc::LOG_FTP,
+            #[cfg(not(any(
+                target_os = "linux",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "macos",
+                target_os = "ios",
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "openbsd",
+                target_os = "netbsd",
+                target_env = "uclibc"
+            )))]
+            Facility::Ftp => libc::LOG_DAEMON,
+            Facility::Kern => libc::LOG_KERN,
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            Facility::Install => libc::LOG_INSTALL,
+            #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+            Facility::Install => libc::LOG_USER,
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            Facility::Launchd => libc::LOG_LAUNCHD,
+            #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+            Facility::Launchd => libc::LOG_DAEMON,
+            Facility::Local0 => libc::LOG_LOCAL0,
+            Facility::Local1 => libc::LOG_LOCAL1,
+            Facility::Local2 => libc::LOG_LOCAL2,
+            Facility::Local3 => libc::LOG_LOCAL3,
+            Facility::Local4 => libc::LOG_LOCAL4,
+            Facility::Local5 => libc::LOG_LOCAL5,
+            Facility::Local6 => libc::LOG_LOCAL6,
+            Facility::Local7 => libc::LOG_LOCAL7,
+            Facility::Lpr => libc::LOG_LPR,
+            Facility::Mail => libc::LOG_MAIL,
+            #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+            Facility::Ntp => libc::LOG_NTP,
+            #[cfg(not(any(target_os = "freebsd", target_os = "dragonfly")))]
+            Facility::Ntp => libc::LOG_DAEMON,
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            Facility::NetInfo => libc::LOG_NETINFO,
+            #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+            Facility::NetInfo => libc::LOG_DAEMON,
+            Facility::News => libc::LOG_NEWS,
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            Facility::Ras => libc::LOG_RAS,
+            #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+            Facility::Ras => libc::LOG_USER,
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            Facility::RemoteAuth => libc::LOG_REMOTEAUTH,
+            #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+            Facility::RemoteAuth => libc::LOG_DAEMON,
+            #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+            Facility::Security => libc::LOG_SECURITY,
+            #[cfg(not(any(target_os = "freebsd", target_os = "dragonfly")))]
+            Facility::Security => libc::LOG_AUTH,
+            Facility::Syslog => libc::LOG_SYSLOG,
+            Facility::User => libc::LOG_USER,
+            Facility::Uucp => libc::LOG_UUCP,
+        }
+    }
+}
+
+impl FromStr for Facility {
+    type Err = UnknownFacilityError;
+
+    fn from_str(s: &str) -> StdResult<Self, Self::Err> {
+        let s = s.to_ascii_lowercase();
+
+        match &*s {
+            "auth"       => Ok(Facility::Auth),
+            "authpriv"   => Ok(Facility::AuthPriv),
+            "cron"       => Ok(Facility::Cron),
+            "daemon"     => Ok(Facility::Daemon),
+            "ftp"        => Ok(Facility::Ftp),
+            "kern"       => Ok(Facility::Kern),
+            "install"    => Ok(Facility::Install),
+            "launchd"    => Ok(Facility::Launchd),
+            "local0"     => Ok(Facility::Local0),
+            "local1"     => Ok(Facility::Local1),
+            "local2"     => Ok(Facility::Local2),
+            "local3"     => Ok(Facility::Local3),
+            "local4"     => Ok(Facility::Local4),
+            "local5"     => Ok(Facility::Local5),
+            "local6"     => Ok(Facility::Local6),
+            "local7"     => Ok(Facility::Local7),
+            "lpr"        => Ok(Facility::Lpr),
+            "mail"       => Ok(Facility::Mail),
+            "ntp"        => Ok(Facility::Ntp),
+            "netinfo"    => Ok(Facility::NetInfo),
+            "news"       => Ok(Facility::News),
+            "ras"        => Ok(Facility::Ras),
+            "remoteauth" => Ok(Facility::RemoteAuth),
+            "security"   => Ok(Facility::Security),
+            "syslog"     => Ok(Facility::Syslog),
+            "user"       => Ok(Facility::User),
+            "uucp"       => Ok(Facility::Uucp),
+            _ => Err(UnknownFacilityError {
+                name: s,
+            })
+        }
+    }
+}
+
+impl TryFrom<c_int> for Facility {
+    type Error = Error;
+
+    fn try_from(value: c_int) -> StdResult<Self, Self::Error> {
+        match value {
+            libc::LOG_AUTH => Ok(Facility::Auth),
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "macos",
+                target_os = "ios",
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "openbsd",
+                target_os = "netbsd",
+                target_env = "uclibc"
+            ))]
+            libc::LOG_AUTHPRIV => Ok(Facility::AuthPriv),
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "macos",
+                target_os = "ios",
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "openbsd",
+                target_os = "netbsd",
+                target_os = "solaris",
+                target_os = "illumos",
+                target_env = "uclibc"
+            ))]
+            libc::LOG_CRON => Ok(Facility::Cron),
+            libc::LOG_DAEMON => Ok(Facility::Daemon),
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "macos",
+                target_os = "ios",
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "openbsd",
+                target_os = "netbsd",
+                target_env = "uclibc"
+            ))]
+            libc::LOG_FTP => Ok(Facility::Ftp),
+            libc::LOG_KERN => Ok(Facility::Kern),
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            libc::LOG_INSTALL => Ok(Facility::Install),
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            libc::LOG_LAUNCHD => Ok(Facility::Launchd),
+            libc::LOG_LOCAL0 => Ok(Facility::Local0),
+            libc::LOG_LOCAL1 => Ok(Facility::Local1),
+            libc::LOG_LOCAL2 => Ok(Facility::Local2),
+            libc::LOG_LOCAL3 => Ok(Facility::Local3),
+            libc::LOG_LOCAL4 => Ok(Facility::Local4),
+            libc::LOG_LOCAL5 => Ok(Facility::Local5),
+            libc::LOG_LOCAL6 => Ok(Facility::Local6),
+            libc::LOG_LOCAL7 => Ok(Facility::Local7),
+            libc::LOG_LPR => Ok(Facility::Lpr),
+            libc::LOG_MAIL => Ok(Facility::Mail),
+            #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+            libc::LOG_NTP => Ok(Facility::Ntp),
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            libc::LOG_NETINFO => Ok(Facility::NetInfo),
+            libc::LOG_NEWS => Ok(Facility::News),
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            libc::LOG_RAS => Ok(Facility::Ras),
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            libc::LOG_REMOTEAUTH => Ok(Facility::RemoteAuth),
+            #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+            libc::LOG_SECURITY => Ok(Facility::Security),
+            libc::LOG_SYSLOG => Ok(Facility::Syslog),
+            libc::LOG_USER => Ok(Facility::User),
+            libc::LOG_UUCP => Ok(Facility::Uucp),
+            _ => Err(ErrorKind::Invalid.into())
+        }
+    }
+}
+
+/// Indicates that `<Facility as FromStr>::from_str` was called with an unknown
+/// facility name.
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
+#[non_exhaustive]
+pub struct UnknownFacilityError {
+    name: String,
+}
+
+impl UnknownFacilityError {
+    /// The unrecognized facility name.
+    pub fn name(&self) -> &str {
+        &*self.name
+    }
+}
+
+impl Display for UnknownFacilityError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "unrecognized syslog facility name `{}`", self.name)
+    }
+}
+
+impl StdError for UnknownFacilityError {}
+
+#[test]
+fn test_facility_from_str() {
+    assert_eq!(Facility::from_str("daemon"), Ok(Facility::Daemon));
+    assert_eq!(Facility::from_str("foobar"), Err(UnknownFacilityError { name: "foobar".to_string() }));
+    assert_eq!(Facility::from_str("foobar").unwrap_err().to_string(), "unrecognized syslog facility name `foobar`");
+}

--- a/src/syslog/format.rs
+++ b/src/syslog/format.rs
@@ -1,0 +1,371 @@
+//! Ways to format syslog messages with structured data.
+//! 
+//! See [`MsgFormat`] for more details.
+//! 
+//! [`MsgFormat`]: trait.MsgFormat.html
+
+use serde::{Deserialize, Serialize};
+use slog::{KV, OwnedKVList, Record};
+use std::cell::Cell;
+use std::fmt::{self, Debug, Display};
+use std::sync::Arc;
+
+/// A way to format syslog messages with structured data.
+/// 
+/// Syslog does not support structured log data. If Slog key-value pairs are to
+/// be included with log messages, they must be included as part of the
+/// message. Implementations of this trait determine if and how this will be
+/// done.
+pub trait MsgFormat: Sync + Send + Debug {
+    /// Formats a log message and its key-value pairs into the given `Formatter`.
+    /// 
+    /// Note that this method returns `slog::Result`, not `std::fmt::Result`.
+    /// The caller of this method is responsible for handling the error,
+    /// likely by storing it elsewhere and picking it up later. See the
+    /// implementation of the `to_string` method for an example of how to do
+    /// this.
+    fn fmt(&self, f: &mut fmt::Formatter, record: &Record, values: &OwnedKVList) -> slog::Result;
+
+    /// Formats a log message and its key-value pairs into a new `String`.
+    fn to_string(&self, record: &Record, values: &OwnedKVList) -> slog::Result<String> {
+        // This helper structure provides a convenient way to implement
+        // `Display` with a closure.
+        struct ClosureAsDisplay<F: Fn(&mut fmt::Formatter) -> fmt::Result>(F);
+        impl<F: Fn(&mut fmt::Formatter) -> fmt::Result> Display for ClosureAsDisplay<F> {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                self.0(f)
+            }
+        }
+
+        // If there is an error calling `self.fmt`, it will be stored here. We
+        // have to use `Cell` because the `Display::fmt` method doesn't get a
+        // mutable reference to `self`.
+        let result: Cell<Option<slog::Error>> = Cell::new(None);
+
+        // Construct our `Display` implementation…
+        let s = ClosureAsDisplay(|f| {
+            // Do the formatting.
+            if let Err(e) = MsgFormat::fmt(self, f, record, values) {
+                // If there's an error, smuggle it out.
+                result.set(Some(e));
+            }
+            // Pretend to succeed, even if there was an error, or else
+            // `to_string` will panic.
+            Ok(())
+        })
+        // …and use it to generate a `String`.
+        .to_string();
+
+        // Extract the error, if any. It should be waiting inside `result`.
+        if let Some(e) = result.take() {
+            Err(e)
+        }
+        else {
+            Ok(s)
+        }
+    }
+}
+
+impl<T: MsgFormat + ?Sized> MsgFormat for &T {
+    fn fmt(&self, f: &mut fmt::Formatter, record: &Record, values: &OwnedKVList) -> slog::Result {
+        MsgFormat::fmt(&**self, f, record, values)
+    }
+}
+
+impl<T: MsgFormat + ?Sized> MsgFormat for Box<T> {
+    fn fmt(&self, f: &mut fmt::Formatter, record: &Record, values: &OwnedKVList) -> slog::Result {
+        MsgFormat::fmt(&**self, f, record, values)
+    }
+}
+
+impl<T: MsgFormat + ?Sized> MsgFormat for Arc<T> {
+    fn fmt(&self, f: &mut fmt::Formatter, record: &Record, values: &OwnedKVList) -> slog::Result {
+        MsgFormat::fmt(&**self, f, record, values)
+    }
+}
+
+/// An implementation of [`MsgFormat`] that discards the key-value pairs and
+/// logs only the [`msg`] part of a log [`Record`].
+/// 
+/// [`msg`]: https://docs.rs/slog/2/slog/struct.Record.html#method.msg
+/// [`MsgFormat`]: trait.MsgFormat.html
+/// [`Record`]: https://docs.rs/slog/2/slog/struct.Record.html
+#[derive(Clone, Copy, Debug, Default)]
+pub struct BasicMsgFormat;
+impl MsgFormat for BasicMsgFormat {
+    fn fmt(&self, f: &mut fmt::Formatter, record: &Record, _: &OwnedKVList) -> slog::Result {
+        write!(f, "{}", record.msg())?;
+        Ok(())
+    }
+}
+
+/// A [`MsgFormat`] implementation that calls a closure to perform the
+/// formatting.
+/// 
+/// This is meant to provide a convenient way to implement a custom
+/// `MsgFormat`.
+/// 
+/// # Example
+/// 
+/// ```
+/// use sloggers::Build;
+/// use sloggers::syslog::SyslogBuilder;
+/// use sloggers::syslog::format::CustomMsgFormat;
+/// 
+/// let logger = SyslogBuilder::new()
+///     .format(CustomMsgFormat(|f, record, _| {
+///         write!(f, "here's a message: {}", record.msg())?;
+///         Ok(())
+///     }))
+///     .build()
+///     .unwrap();
+/// ```
+/// 
+/// Note the use of the `?` operator. The closure is expected to return
+/// `Result<(), slog::Error>`, not the `Result<(), std::fmt::Error>` that
+/// `write!` returns. `slog::Error` does have a conversion from
+/// `std::fmt::Error`, which the `?` operator will automatically perform.
+/// 
+/// [`MsgFormat`]: trait.MsgFormat.html
+pub struct CustomMsgFormat<T: Fn(&mut fmt::Formatter, &Record, &OwnedKVList) -> slog::Result + Send + Sync>(pub T);
+impl<T: Fn(&mut fmt::Formatter, &Record, &OwnedKVList) -> slog::Result + Send + Sync> MsgFormat for CustomMsgFormat<T> {
+    fn fmt(&self, f: &mut fmt::Formatter, record: &Record, values: &OwnedKVList) -> slog::Result {
+        self.0(f, record, values)
+    }
+}
+impl<T: Fn(&mut fmt::Formatter, &Record, &OwnedKVList) -> slog::Result + Send + Sync> Debug for CustomMsgFormat<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CustomMsgFormat").finish()
+    }
+}
+
+/// Copies input to output, but escapes characters as prescribed by RFC 5424 for PARAM-VALUEs.
+struct Rfc5424LikeValueEscaper<W: fmt::Write>(W);
+
+impl<W: fmt::Write> fmt::Write for Rfc5424LikeValueEscaper<W> {
+    fn write_str(&mut self, mut s: &str) -> fmt::Result {
+        while let Some(index) = s.find(|c| c == '\\' || c == '"' || c == ']') {
+            if index != 0 {
+                self.0.write_str(&s[..index])?;
+            }
+
+            // All three delimiters are ASCII characters, so this won't have bogus results.
+            self.write_char(s.as_bytes()[index] as char)?;
+
+            if s.len() >= index {
+                s = &s[(index + 1)..];
+            }
+            else {
+                s = &"";
+                break;
+            }
+        }
+
+        if !s.is_empty() {
+            self.0.write_str(s)?;
+        }
+
+        Ok(())
+    }
+
+    fn write_char(&mut self, c: char) -> fmt::Result {
+        match c {
+            '\\' => self.0.write_str(r"\\"),
+            '"' => self.0.write_str("\\\""),
+            ']' => self.0.write_str("\\]"),
+            _ => write!(self.0, "{}", c)
+        }
+    }
+}
+
+#[test]
+fn test_rfc_5424_like_value_escaper() {
+    use std::iter;
+
+    fn case(input: &str, expected_output: &str) {
+        let mut e = Rfc5424LikeValueEscaper(String::new());
+        fmt::Write::write_str(&mut e, input).unwrap();
+        assert_eq!(e.0, expected_output);
+    }
+
+    // Test that each character is properly escaped.
+    for c in &['\\', '"', ']'] {
+        let ec = format!("\\{}", c);
+
+        {
+            let input = format!("{}", c);
+            case(&*input, &*ec);
+        }
+
+        for at_start_count in 0..=2 {
+        for at_mid_count in 0..=2 {
+        for at_end_count in 0..=2 {
+            // First, we assemble the input and expected output strings.
+            let mut input = String::new();
+            let mut expected_output = String::new();
+
+            // Place the symbol(s) at the beginning of the strings.
+            input.extend(iter::repeat(c).take(at_start_count));
+            expected_output.extend(iter::repeat(&*ec).take(at_start_count));
+
+            // First plain text.
+            input.push_str("foo");
+            expected_output.push_str("foo");
+
+            // Middle symbol(s).
+            input.extend(iter::repeat(c).take(at_mid_count));
+            expected_output.extend(iter::repeat(&*ec).take(at_mid_count));
+
+            // Second plain text.
+            input.push_str("bar");
+            expected_output.push_str("bar");
+
+            // End symbol(s).
+            input.extend(iter::repeat(c).take(at_end_count));
+            expected_output.extend(iter::repeat(&*ec).take(at_end_count));
+
+            // Finally, test this combination.
+            case(&*input, &*expected_output);
+        }}}
+    }
+
+    case("", "");
+    case("foo", "foo");
+    case("[foo]", "[foo\\]");
+    case("\\\"]", "\\\\\\\"\\]"); // \"] ⇒ \\\"\]
+}
+
+/// An implementation of [`MsgFormat`] that formats the key-value pairs of a
+/// log [`Record`] similarly to [RFC 5424].
+/// 
+/// # Not really RFC 5424
+/// 
+/// This does not actually generate conformant RFC 5424 STRUCTURED-DATA. The
+/// differences are:
+/// 
+/// * All key-value pairs are placed into a single SD-ELEMENT.
+/// * The SD-ELEMENT does not contain an SD-ID, only SD-PARAMs.
+/// * PARAM-NAMEs are encoded in UTF-8, not ASCII.
+/// * Forbidden characters in PARAM-NAMEs are not filtered out, nor is an error
+///   raised if a key contains such characters.
+/// 
+/// # Example output
+/// 
+/// Given a log message `Hello, world!`, where the key `key1` has the value
+/// `value1` and `key2` has the value `value2`, the formatted message will be
+/// `Hello, world! [key1="value1" key2="value2"]` (possibly with `key2` first
+/// instead of `key1`).
+/// 
+/// [`MsgFormat`]: trait.MsgFormat.html
+/// [`Record`]: https://docs.rs/slog/2/slog/struct.Record.html
+/// [RFC 5424]: https://tools.ietf.org/html/rfc5424
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DefaultMsgFormat;
+impl MsgFormat for DefaultMsgFormat {
+    fn fmt(&self, f: &mut fmt::Formatter, record: &Record, values: &OwnedKVList) -> slog::Result {
+        struct SerializerImpl<'a, 'b> {
+            f: &'a mut fmt::Formatter<'b>,
+            is_first_kv: bool,
+        }
+
+        impl<'a, 'b> SerializerImpl<'a, 'b> {
+            fn new(f: &'a mut fmt::Formatter<'b>) -> Self {
+                Self { f, is_first_kv: true }
+            }
+
+            fn finish(&mut self) -> slog::Result {
+                if !self.is_first_kv {
+                    write!(self.f, "]")?;
+                }
+                Ok(())
+            }
+        }
+        
+        impl<'a, 'b> slog::Serializer for SerializerImpl<'a, 'b> {
+            fn emit_arguments(&mut self, key: slog::Key, val: &fmt::Arguments) -> slog::Result {
+                use fmt::Write;
+
+                self.f.write_str(if self.is_first_kv {" ["} else {" "})?;
+                self.is_first_kv = false;
+
+                // Write the key unaltered, but escape the value.
+                //
+                // RFC 5424 does not allow space, ']', '"', or '\' to
+                // appear in PARAM-NAMEs, and does not allow such
+                // characters to be escaped.
+                write!(self.f, "{}=\"", key)?;
+                write!(Rfc5424LikeValueEscaper(&mut self.f), "{}", val)?;
+                self.f.write_char('"')?;
+                Ok(())
+            }
+        }
+
+        write!(f, "{}", record.msg())?;
+
+        {
+            let mut serializer = SerializerImpl::new(f);
+
+            values.serialize(record, &mut serializer)?;
+            record.kv().serialize(record, &mut serializer)?;
+            serializer.finish()?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Makes sure the example output for `DefaultMsgFormat` is what it actually
+/// generates.
+#[test]
+fn test_default_msg_format() {
+    use slog::Level;
+
+    let result = DefaultMsgFormat.to_string(
+        &record!(
+            Level::Info,
+            "",
+            &format_args!("Hello, world!"),
+            b!("key1" => "value1")
+        ),
+        &o!("key2" => "value2").into(),
+    ).expect("formatting failed");
+
+    assert!(
+        // The KVs' order is not well-defined, so they might get reversed.
+        result == "Hello, world! [key1=\"value1\" key2=\"value2\"]" ||
+        result == "Hello, world! [key2=\"value2\" key1=\"value1\"]"
+    );
+}
+
+/// Enumeration of built-in `MsgFormat`s, for use with serde.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum MsgFormatConfig {
+    /// [`DefaultMsgFormat`](struct.DefaultMsgFormat.html).
+    Default,
+
+    /// [`BasicMsgFormat`](struct.BasicMsgFormat.html).
+    Basic,
+}
+
+impl Default for MsgFormatConfig {
+    fn default() -> Self {
+        MsgFormatConfig::Default
+    }
+}
+
+impl From<MsgFormatConfig> for Arc<dyn MsgFormat> {
+    fn from(conf: MsgFormatConfig) -> Self {
+        Self::from(&conf)
+    }
+}
+
+impl From<&MsgFormatConfig> for Arc<dyn MsgFormat> {
+    fn from(conf: &MsgFormatConfig) -> Self {
+        match *conf {
+            MsgFormatConfig::Default => Arc::new(DefaultMsgFormat),
+            MsgFormatConfig::Basic => Arc::new(BasicMsgFormat),
+        }
+    }
+}

--- a/src/syslog/mock.rs
+++ b/src/syslog/mock.rs
@@ -1,0 +1,88 @@
+//! Mocks for the POSIX `syslog` API.
+//! 
+//! The mock `syslog` function here is a bit different from the real one. It
+//! takes exactly three parameters, whereas the real one takes two or more.
+//! This works for our purposes because this crate always calls it with exactly
+//! three parameters anyway.
+
+use libc::{c_char, c_int};
+use once_cell::sync::Lazy;
+use std::ffi::CStr;
+use std::mem;
+use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
+use std::sync::{Condvar, Mutex, MutexGuard};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Event {
+    OpenLog {
+        ident: String,
+        flags: c_int,
+        facility: c_int,
+    },
+    CloseLog,
+    SysLog {
+        priority: c_int,
+        message_f: String,
+        message: String,
+    },
+    DropOwnedIdent(String),
+}
+
+static EVENTS: Lazy<Mutex<Vec<Event>>> = Lazy::new(|| Mutex::new(Vec::new()));
+static EVENTS_CV: Lazy<Condvar> = Lazy::new(|| Condvar::new());
+static TESTING: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+pub fn testing<T>(f: impl FnOnce() -> T) -> (T, Vec<Event>) {
+    let _locked = TESTING.lock().unwrap();
+
+    let result = catch_unwind(AssertUnwindSafe(f));
+    let events = take_events();
+
+    match result {
+        Ok(ok) => (ok, events),
+        Err(panicked) => resume_unwind(panicked),
+    }
+}
+
+pub fn take_events() -> Vec<Event> {
+    let mut events: MutexGuard<Vec<Event>> = EVENTS.lock().unwrap();
+    mem::take(&mut *events)
+}
+
+pub fn push_event(event: Event) {
+    let mut events: MutexGuard<Vec<Event>> = EVENTS.lock().unwrap();
+    events.push(event);
+    EVENTS_CV.notify_all();
+}
+
+pub fn wait_for_event_matching(matching: impl Fn(&Event) -> bool) {
+    let mut events: MutexGuard<Vec<Event>> = EVENTS.lock().unwrap();
+
+    while !events.iter().any(&matching) {
+        events = EVENTS_CV.wait(events).unwrap();
+    }
+}
+
+pub unsafe extern "C" fn openlog(ident: *const c_char, logopt: c_int, facility: c_int) {
+    push_event(Event::OpenLog {
+        ident: string_from_ptr(ident),
+        flags: logopt,
+        facility,
+    });
+}
+
+pub unsafe extern "C" fn closelog() {
+    push_event(Event::CloseLog);
+}
+
+pub unsafe extern "C" fn syslog(priority: c_int, message_f: *const c_char, message: *const c_char) {
+    push_event(Event::SysLog {
+        priority,
+        message_f: string_from_ptr(message_f),
+        message: string_from_ptr(message),
+    });
+}
+
+pub unsafe fn string_from_ptr(ptr: *const c_char) -> String {
+    String::from(CStr::from_ptr(ptr).to_string_lossy())
+}

--- a/src/syslog/tests.rs
+++ b/src/syslog/tests.rs
@@ -1,0 +1,104 @@
+use crate::Build;
+use crate::syslog::{Facility, mock, SyslogBuilder};
+use crate::syslog::format::CustomMsgFormat;
+use crate::types::{Severity, SourceLocation};
+use slog::{debug, info};
+use std::ffi::CStr;
+
+#[test]
+fn test_log() {
+    let ((), events) = mock::testing(|| {
+        {
+            let tmp_logger = SyslogBuilder::new()
+                .ident_str("hello")
+                .log_ndelay()
+                .log_odelay()
+                .log_pid()
+                .level(Severity::Debug)
+                .source_location(SourceLocation::None)
+                .build()
+                .unwrap();
+
+            debug!(tmp_logger, "Constructed a temporary logger.");
+
+            // The logger will be dropped at this point, which should result in
+            // a `closelog` call.
+        }
+
+        let logger = SyslogBuilder::new()
+            .facility(Facility::Local0)
+            .level(Severity::Debug)
+            .ident_str("sloggers-example-app")
+            .source_location(SourceLocation::None)
+            .build()
+            .unwrap();
+
+        info!(logger, "Hello, world! This is a test message from `sloggers::syslog`."; "test" => "message");
+
+        mock::wait_for_event_matching(|event| match event {
+            mock::Event::SysLog { message, .. } => message.contains("This is a test message"),
+            _ => false,
+        });
+
+        let logger2 = SyslogBuilder::new()
+            .facility(Facility::Local1)
+            .ident(CStr::from_bytes_with_nul(b"logger2\0").unwrap())
+            .source_location(SourceLocation::None)
+            .format(CustomMsgFormat(|_, _, _| Err(slog::Error::Other)))
+            .build()
+            .unwrap();
+
+        info!(logger2, "Message from second logger while first still active."; "key" => "value");
+
+        mock::wait_for_event_matching(|event| match event {
+            mock::Event::SysLog { message, .. } => message == &slog::Error::Other.to_string(),
+            _ => false,
+        });
+    });
+
+    let expected_events = vec![
+        mock::Event::OpenLog {
+            facility: libc::LOG_USER,
+            flags: libc::LOG_ODELAY | libc::LOG_PID,
+            ident: "hello".to_string(),
+        },
+        mock::Event::SysLog {
+            priority: libc::LOG_DEBUG,
+            message_f: "%s".to_string(),
+            message: "Constructed a temporary logger.".to_string(),
+        },
+        // This logger will `closelog` when dropped, because it has to in order
+        // to free its `ident` string.
+        mock::Event::CloseLog,
+        mock::Event::DropOwnedIdent("hello".to_string()),
+        mock::Event::OpenLog {
+            facility: libc::LOG_LOCAL0,
+            flags: 0,
+            ident: "sloggers-example-app".to_string(),
+        },
+        mock::Event::SysLog {
+            priority: libc::LOG_INFO,
+            message_f: "%s".to_string(),
+            message: "Hello, world! This is a test message from `sloggers::syslog`. [test=\"message\"]".to_string()
+        },
+        mock::Event::OpenLog {
+            facility: libc::LOG_LOCAL1,
+            flags: 0,
+            ident: "logger2".to_string(),
+        },
+        mock::Event::SysLog {
+            priority: libc::LOG_INFO,
+            message_f: "%s".to_string(),
+            message: "Message from second logger while first still active.".to_string(),
+        },
+        mock::Event::SysLog {
+            priority: libc::LOG_ERR,
+            message_f: "Error fully formatting the previous log message: %s".to_string(),
+            message: slog::Error::Other.to_string(),
+        },
+        mock::Event::DropOwnedIdent("sloggers-example-app".to_string()),
+        // No `CloseLog` for `logger2` because it doesn't own its `ident`.
+    ];
+
+    assert!(events == expected_events, "events didn't match\ngot: {:#?}\nexpected: {:#?}", events, expected_events);
+}

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,47 +1,34 @@
 //! Terminal logger.
+use crate::build::BuilderCommon;
 use crate::misc;
 #[cfg(feature = "slog-kvfilter")]
 use crate::types::KVFilterParameters;
 use crate::types::{Format, OverflowStrategy, Severity, SourceLocation, TimeZone};
 use crate::{Build, Config, Result};
 use serde::{Deserialize, Serialize};
-use slog::{self, Drain, FnValue, Logger};
-use slog_async::Async;
-#[cfg(feature = "slog-kvfilter")]
-use slog_kvfilter::KVFilter;
+use slog::Logger;
 use slog_term::{self, CompactFormat, FullFormat, PlainDecorator, TermDecorator};
 use std::fmt::Debug;
 use std::io;
-use std::panic::{RefUnwindSafe, UnwindSafe};
 
 /// A logger builder which build loggers that output log records to the terminal.
 ///
 /// The resulting logger will work asynchronously (the default channel size is 1024).
 #[derive(Debug)]
 pub struct TerminalLoggerBuilder {
+    common: BuilderCommon,
     format: Format,
-    source_location: SourceLocation,
     timezone: TimeZone,
     destination: Destination,
-    overflow_strategy: OverflowStrategy,
-    level: Severity,
-    channel_size: usize,
-    #[cfg(feature = "slog-kvfilter")]
-    kvfilterparameters: Option<KVFilterParameters>,
 }
 impl TerminalLoggerBuilder {
     /// Makes a new `TerminalLoggerBuilder` instance.
     pub fn new() -> Self {
         TerminalLoggerBuilder {
+            common: BuilderCommon::default(),
             format: Format::default(),
-            source_location: SourceLocation::default(),
-            overflow_strategy: OverflowStrategy::default(),
             timezone: TimeZone::default(),
             destination: Destination::default(),
-            level: Severity::default(),
-            channel_size: 1024,
-            #[cfg(feature = "slog-kvfilter")]
-            kvfilterparameters: None,
         }
     }
 
@@ -53,13 +40,13 @@ impl TerminalLoggerBuilder {
 
     /// Sets the source code location type this logger will use.
     pub fn source_location(&mut self, source_location: SourceLocation) -> &mut Self {
-        self.source_location = source_location;
+        self.common.source_location = source_location;
         self
     }
 
     /// Sets the overflow strategy for the logger.
     pub fn overflow_strategy(&mut self, overflow_strategy: OverflowStrategy) -> &mut Self {
-        self.overflow_strategy = overflow_strategy;
+        self.common.overflow_strategy = overflow_strategy;
         self
     }
 
@@ -77,13 +64,13 @@ impl TerminalLoggerBuilder {
 
     /// Sets the log level of this logger.
     pub fn level(&mut self, severity: Severity) -> &mut Self {
-        self.level = severity;
+        self.common.level = severity;
         self
     }
 
     /// Sets the size of the asynchronous channel of this logger.
     pub fn channel_size(&mut self, channel_size: usize) -> &mut Self {
-        self.channel_size = channel_size;
+        self.common.channel_size = channel_size;
         self
     }
 
@@ -92,70 +79,8 @@ impl TerminalLoggerBuilder {
     /// [`KVFilter`]: https://docs.rs/slog-kvfilter/0.6/slog_kvfilter/struct.KVFilter.html
     #[cfg(feature = "slog-kvfilter")]
     pub fn kvfilter(&mut self, parameters: KVFilterParameters) -> &mut Self {
-        self.kvfilterparameters = Some(parameters);
+        self.common.kvfilterparameters = Some(parameters);
         self
-    }
-
-    #[cfg(feature = "slog-kvfilter")]
-    fn build_with_drain<D>(&self, drain: D) -> Logger
-    where
-        D: Drain + Send + 'static,
-        D::Err: Debug,
-    {
-        // async inside, level and key value filters outside for speed
-        let drain = Async::new(drain.fuse())
-            .chan_size(self.channel_size)
-            .overflow_strategy(self.overflow_strategy.to_async_type())
-            .build()
-            .fuse();
-
-        if let Some(ref p) = self.kvfilterparameters {
-            let kvdrain = KVFilter::new(drain, p.severity.as_level())
-                .always_suppress_any(p.always_suppress_any.clone())
-                .only_pass_any_on_all_keys(p.only_pass_any_on_all_keys.clone())
-                .always_suppress_on_regex(p.always_suppress_on_regex.clone())
-                .only_pass_on_regex(p.only_pass_on_regex.clone());
-            self.build_logger(kvdrain)
-        } else {
-            self.build_logger(drain)
-        }
-    }
-
-    #[cfg(not(feature = "slog-kvfilter"))]
-    fn build_with_drain<D>(&self, drain: D) -> Logger
-    where
-        D: Drain + Send + 'static,
-        D::Err: Debug,
-    {
-        // async inside, level and key value filters outside for speed
-        let drain = Async::new(drain.fuse())
-            .chan_size(self.channel_size)
-            .overflow_strategy(self.overflow_strategy.to_async_type())
-            .build()
-            .fuse();
-        self.build_logger(drain)
-    }
-
-    fn build_logger<D>(&self, drain: D) -> Logger
-    where
-        D: Drain + Send + Sync + UnwindSafe + RefUnwindSafe + 'static,
-        D::Err: Debug,
-    {
-        let drain = self.level.set_level_filter(drain.fuse());
-
-        match self.source_location {
-            SourceLocation::None => Logger::root(drain.fuse(), o!()),
-            SourceLocation::ModuleAndLine => {
-                Logger::root(drain.fuse(), o!("module" => FnValue(misc::module_and_line)))
-            }
-            SourceLocation::FileAndLine => {
-                Logger::root(drain.fuse(), o!("module" => FnValue(misc::file_and_line)))
-            }
-            SourceLocation::LocalFileAndLine => Logger::root(
-                drain.fuse(),
-                o!("module" => FnValue(misc::local_file_and_line)),
-            ),
-        }
     }
 }
 impl Default for TerminalLoggerBuilder {
@@ -170,11 +95,11 @@ impl Build for TerminalLoggerBuilder {
         let logger = match self.format {
             Format::Full => {
                 let format = FullFormat::new(decorator).use_custom_timestamp(timestamp);
-                self.build_with_drain(format.build())
+                self.common.build_with_drain(format.build())
             }
             Format::Compact => {
                 let format = CompactFormat::new(decorator).use_custom_timestamp(timestamp);
-                self.build_with_drain(format.build())
+                self.common.build_with_drain(format.build())
             }
         };
         Ok(logger)


### PR DESCRIPTION
This PR adds support for emitting log messages using the POSIX `syslog` API.

Specifically, this PR adds a `syslog` module, and adds support for it to `LoggerBuilder` and `LoggerConfig`. These are available on Unix-like platforms only. On other platforms (like Windows), the POSIX `syslog` API doesn't exist, so the `syslog` module is not available on that platform. Trying to load a syslog configuration on a non-Unix platform will result in a specific error message during deserialization.

Also, this refactors the code that builds a `Logger` from a bare `Drain` into the new `build::BuilderCommon`, since it's used by all three logger builders.

Tested on `x86_64-unknown-linux-gnu` and `x86_64-pc-windows-msvc`. (Only one test actually applies to Windows. It tries to deserialize a TOML logging configuration that says to use syslog, and makes sure the error message says it's unavailable on that platform.)

Design and rationale is explained in a comment in `src/syslog.rs` starting at line 36.

One thing I'm not sure of: should the syslog drain implementation be in a separate crate, or built into sloggers like I've done here?