### PR TITLE
Change default `terminal::Destination` to `Stderr`

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -190,7 +190,7 @@ impl Build for TerminalLoggerBuilder {
 /// ```
 /// use sloggers::terminal::Destination;
 ///
-/// assert_eq!(Destination::default(), Destination::Stdout);
+/// assert_eq!(Destination::default(), Destination::Stderr);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -203,7 +203,7 @@ pub enum Destination {
 }
 impl Default for Destination {
     fn default() -> Self {
-        Destination::Stdout
+        Destination::Stderr
     }
 }
 impl Destination {


### PR DESCRIPTION
Trivial change that fixes #31.