### PR TITLE
Add "json" feature to support Format::Json format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ codecov = {repository = "sile/sloggers"}
 
 [features]
 default = ["libflate", "slog-kvfilter"]
+json = ["slog-json"]
 
 [dependencies]
 chrono="0.4"
@@ -26,6 +27,7 @@ slog-async = "2"
 slog-term = "2"
 slog-scope = "4"
 slog-kvfilter = {version = "~0.7", optional = true}
+slog-json = {version = "2.3.0", optional = true}
 slog-stdlog = "4"
 trackable = "1"
 regex="1"

--- a/src/file.rs
+++ b/src/file.rs
@@ -140,16 +140,22 @@ impl FileLoggerBuilder {
 
 impl Build for FileLoggerBuilder {
     fn build(&self) -> Result<Logger> {
-        let decorator = PlainDecorator::new(self.appender.clone());
         let timestamp = misc::timezone_to_timestamp_fn(self.timezone);
         let logger = match self.format {
             Format::Full => {
+                let decorator = PlainDecorator::new(self.appender.clone());
                 let format = FullFormat::new(decorator).use_custom_timestamp(timestamp);
                 self.common.build_with_drain(format.build())
             }
             Format::Compact => {
+                let decorator = PlainDecorator::new(self.appender.clone());
                 let format = CompactFormat::new(decorator).use_custom_timestamp(timestamp);
                 self.common.build_with_drain(format.build())
+            }
+            #[cfg(feature = "json")]
+            Format::Json => {
+                let drain = slog_json::Json::default(self.appender.clone());
+                self.common.build_with_drain(drain)
             }
         };
         Ok(logger)

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -101,6 +101,13 @@ impl Build for TerminalLoggerBuilder {
                 let format = CompactFormat::new(decorator).use_custom_timestamp(timestamp);
                 self.common.build_with_drain(format.build())
             }
+            #[cfg(feature = "json")]
+            Format::Json => {
+                match self.destination {
+                    Destination::Stdout => self.common.build_with_drain(slog_json::Json::default(std::io::stdout())),
+                    Destination::Stderr => self.common.build_with_drain(slog_json::Json::default(std::io::stderr())),
+                }
+            }
         };
         Ok(logger)
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -168,6 +168,10 @@ pub enum Format {
 
     /// Compact format.
     Compact,
+
+    /// JSON format.
+    #[cfg(feature = "json")]
+    Json,
 }
 impl Default for Format {
     fn default() -> Self {
@@ -180,6 +184,8 @@ impl FromStr for Format {
         match s {
             "full" => Ok(Format::Full),
             "compact" => Ok(Format::Compact),
+            #[cfg(feature = "json")]
+            "json" => Ok(Format::Json),
             _ => track_panic!(ErrorKind::Invalid, "Undefined log format: {:?}", s),
         }
     }


### PR DESCRIPTION
resolves #40 

This implementation is based on `slog-json` crate and can be enabled by `json` feature flag.

I just created the corresponding issue #40 and was not sure if you'd like to add JSON in the first place, so feel free to close this PR if you don't like it.