### PR TITLE
Fix `set_stdlog_logger()` to return `GlobalLoggerGuard` instance.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ regex="1"
 
 [dev-dependencies]
 clap = "2"
+log = "0.4"
 serdeconv = "0.4"
 tempfile = "3"
 

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -1,14 +1,29 @@
 use crate::types::TimeZone;
-use crate::{ErrorKind, Result};
+use crate::{Error, ErrorKind, Result};
 use slog::{Logger, Record};
 use std::io;
 use std::path::Path;
 use trackable::error::ErrorKindExt;
 
 /// Sets the logger for the log records emitted via `log` crate.
-pub fn set_stdlog_logger(logger: Logger) -> Result<()> {
-    let _guard = slog_scope::set_global_logger(logger);
-    track!(slog_stdlog::init().map_err(|e| ErrorKind::Other.cause(e).into()))
+///
+/// # Examples
+///
+/// ```
+/// use sloggers::Build as _;
+///
+/// # fn main() -> sloggers::Result<()> {
+/// let logger = sloggers::terminal::TerminalLoggerBuilder::new().build()?;
+/// let _guard = sloggers::set_stdlog_logger(logger.clone())?;
+///
+/// slog::info!(logger, "Hello ");
+/// log::info!("World!");
+/// # Ok(())
+/// # }
+/// ```
+pub fn set_stdlog_logger(logger: Logger) -> Result<slog_scope::GlobalLoggerGuard> {
+    track!(slog_stdlog::init().map_err(|e| Error::from(ErrorKind::Other.cause(e))))?;
+    Ok(slog_scope::set_global_logger(logger))
 }
 
 pub fn module_and_line(record: &Record) -> String {


### PR DESCRIPTION
Resolves #49 