### PR TITLE
Add `restrict_permissions` to `FileLoggerBuilder`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,7 @@ tempfile = "3"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 once_cell = "1"
+
+[target.'cfg(windows)'.dependencies]
+winapi = "~0.3.5"
+windows-acl = "~0.3.0"

--- a/src/file.rs
+++ b/src/file.rs
@@ -260,27 +260,13 @@ impl FileAppender {
             // handle, we get a Permission denied on Windows. Release the handle.
             self.file = None;
 
-            #[cfg(unix)]
             let mut file = file_builder
                 .append(!self.truncate)
                 .write(true)
                 .open(&self.path)?;
 
-            #[cfg(windows)]
-            let file = file_builder
-                .append(!self.truncate)
-                .write(true)
-                .open(&self.path)?;
-
             if self.restrict_permissions {
-                #[cfg(unix)]
-                {
-                    file = restrict_file_permissions(file)?;
-                }
-                #[cfg(windows)]
-                {
-                    restrict_file_permissions(&self.path)?;
-                }
+                file = restrict_file_permissions(&self.path, file)?;
             }
             self.written_size = file.metadata()?.len();
             self.file = Some(BufWriter::new(file));

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,6 +1,7 @@
 //! File logger.
 use crate::build::BuilderCommon;
 use crate::misc;
+use crate::permissions::restrict_file_permissions;
 #[cfg(feature = "slog-kvfilter")]
 use crate::types::KVFilterParameters;
 use crate::types::{Format, OverflowStrategy, Severity, SourceLocation, TimeZone};
@@ -136,6 +137,19 @@ impl FileLoggerBuilder {
         self.appender.rotate_compress = compress;
         self
     }
+
+    /// Sets whether the log files should have restricted permissions.
+    ///
+    /// If `true` is specified, new log files will be created with the `600` octal permission
+    /// on unix systems.
+    /// On Windows systems, new log files will have an ACL which just contains the SID of
+    /// the owner.
+    ///
+    /// The default value is `false`.
+    pub fn restrict_permissions(&mut self, restrict: bool) -> &mut Self {
+        self.appender.restrict_permissions = restrict;
+        self
+    }
 }
 
 impl Build for FileLoggerBuilder {
@@ -179,6 +193,7 @@ struct FileAppender {
     wait_compression: Option<mpsc::Receiver<io::Result<()>>>,
     next_reopen_check: Instant,
     reopen_check_interval: Duration,
+    restrict_permissions: bool,
 }
 
 impl Clone for FileAppender {
@@ -196,6 +211,7 @@ impl Clone for FileAppender {
             wait_compression: None,
             next_reopen_check: Instant::now(),
             reopen_check_interval: self.reopen_check_interval,
+            restrict_permissions: self.restrict_permissions,
         }
     }
 }
@@ -215,6 +231,7 @@ impl FileAppender {
             wait_compression: None,
             next_reopen_check: Instant::now(),
             reopen_check_interval: Duration::from_millis(1000),
+            restrict_permissions: false,
         }
     }
 
@@ -242,10 +259,29 @@ impl FileAppender {
             // If the old file was externally deleted and we attempt to open a new one before releasing the old
             // handle, we get a Permission denied on Windows. Release the handle.
             self.file = None;
+
+            #[cfg(unix)]
+            let mut file = file_builder
+                .append(!self.truncate)
+                .write(true)
+                .open(&self.path)?;
+
+            #[cfg(windows)]
             let file = file_builder
                 .append(!self.truncate)
                 .write(true)
                 .open(&self.path)?;
+
+            if self.restrict_permissions {
+                #[cfg(unix)]
+                {
+                    file = restrict_file_permissions(file)?;
+                }
+                #[cfg(windows)]
+                {
+                    restrict_file_permissions(&self.path)?;
+                }
+            }
             self.written_size = file.metadata()?.len();
             self.file = Some(BufWriter::new(file));
         }
@@ -485,6 +521,14 @@ pub struct FileLoggerConfig {
     /// The default value is `drop_and_report`.
     #[serde(default)]
     pub overflow_strategy: OverflowStrategy,
+
+    /// Whether to restrict the permissions of log files.
+    ///
+    /// For details, see the documentation of [`restict_permissions`].
+    ///
+    /// [`restrict_permissions`]: ./struct.FileLoggerBuilder.html#method.restrict_permissions
+    #[serde(default)]
+    pub restrict_permissions: bool,
 }
 
 impl FileLoggerConfig {
@@ -512,6 +556,7 @@ impl Config for FileLoggerConfig {
         builder.rotate_keep(self.rotate_keep);
         #[cfg(feature = "libflate")]
         builder.rotate_compress(self.rotate_compress);
+        builder.restrict_permissions(self.restrict_permissions);
         if self.truncate {
             builder.truncate();
         }
@@ -535,6 +580,7 @@ impl Default for FileLoggerConfig {
             rotate_keep: default_rotate_keep(),
             #[cfg(feature = "libflate")]
             rotate_compress: false,
+            restrict_permissions: false,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ mod config;
 mod error;
 mod fake_syslog;
 mod misc;
+mod permissions;
 
 /// A specialized `Result` type for this crate.
 pub type Result<T> = ::std::result::Result<T, Error>;

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -107,3 +107,11 @@ pub fn restrict_file_permissions<P: AsRef<Path>>(path: P, file: File) -> io::Res
     }
     Ok(file)
 }
+
+#[cfg(not(any(unix, windows)))]
+pub fn restrict_file_permissions<P: AsRef<Path>>(_path: P, _file: File) -> io::Result<File> {
+    Err(io::Error::new(
+        io::ErrorKind::Other,
+        "`restrict_permissions` feature is only available on Unix or Windows",
+    ))
+}

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -1,0 +1,111 @@
+//! Cross platform functions to restrict file permissions when using the file logger.
+#[cfg(unix)]
+use std::fs::File;
+use std::io;
+#[cfg(windows)]
+use std::path::Path;
+#[cfg(windows)]
+use winapi::um::winnt::{FILE_GENERIC_READ, FILE_GENERIC_WRITE, STANDARD_RIGHTS_ALL};
+
+/// This is the security identifier in Windows for the owner of a file. See:
+/// - https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/security-identifiers-in-windows#well-known-sids-all-versions-of-windows
+#[cfg(windows)]
+const OWNER_SID_STR: &str = "S-1-3-4";
+/// We don't need any of the `AceFlags` listed here:
+/// - https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-ace_header
+#[cfg(windows)]
+const OWNER_ACL_ENTRY_FLAGS: u8 = 0;
+/// Generic Rights:
+///  - https://docs.microsoft.com/en-us/windows/win32/fileio/file-security-and-access-rights
+/// Individual Read/Write/Execute Permissions (referenced in generic rights link):
+///  - https://docs.microsoft.com/en-us/windows/win32/wmisdk/file-and-directory-access-rights-constants
+/// STANDARD_RIGHTS_ALL
+///  - https://docs.microsoft.com/en-us/windows/win32/secauthz/access-mask
+#[cfg(windows)]
+const OWNER_ACL_ENTRY_MASK: u32 = FILE_GENERIC_READ | FILE_GENERIC_WRITE | STANDARD_RIGHTS_ALL;
+
+/// Function to set the umask of the log files to `600`.
+///
+/// This ensures the log files are not world-readable.
+#[cfg(unix)]
+pub fn restrict_file_permissions(file: File) -> io::Result<File> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perm = file.metadata()?.permissions();
+    perm.set_mode(0o600);
+    file.set_permissions(perm)?;
+
+    Ok(file)
+}
+
+/// Function to set the access control lists (ACLs) of the log files to only include the owner.
+/// This is equivalent to a umask of `600` on `unix` systems.
+///
+/// This ensures the log fiels are not world-readable.
+#[cfg(windows)]
+pub fn restrict_file_permissions<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    use winapi::um::winnt::PSID;
+    use windows_acl::acl::{AceType, ACL};
+    use windows_acl::helper::sid_to_string;
+
+    let path_str = path.as_ref().to_str().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            "Unable to open file path.".to_string(),
+        )
+    })?;
+
+    let mut acl = ACL::from_file_path(path_str, false).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            format!("Unable to retrieve ACL: {:?}", e),
+        )
+    })?;
+
+    let owner_sid = windows_acl::helper::string_to_sid(OWNER_SID_STR).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            format!("Unable to convert SID: {:?}", e),
+        )
+    })?;
+
+    let entries = acl.all().map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            format!("Unable to enumerate ACL entries: {:?}", e),
+        )
+    })?;
+
+    // Add single entry for file owner.
+    acl.add_entry(
+        owner_sid.as_ptr() as PSID,
+        AceType::AccessAllow,
+        OWNER_ACL_ENTRY_FLAGS,
+        OWNER_ACL_ENTRY_MASK,
+    )
+    .map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            format!(
+                "Failed to add ACL entry for SID {} error={}",
+                OWNER_SID_STR, e
+            ),
+        )
+    })?;
+    // Remove all AccessAllow entries from the file that aren't the owner_sid.
+    for entry in &entries {
+        if let Some(ref entry_sid) = entry.sid {
+            let entry_sid_str = sid_to_string(entry_sid.as_ptr() as PSID)
+                .unwrap_or_else(|_| "BadFormat".to_string());
+            if entry_sid_str != OWNER_SID_STR {
+                acl.remove(entry_sid.as_ptr() as PSID, Some(AceType::AccessAllow), None)
+                    .map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::Other,
+                            format!("Failed to remove ACL entry for SID {}", entry_sid_str),
+                        )
+                    })?;
+            }
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
Resolves #17

This PR adds a new method to `FileLoggerBuilder` which restricts log file permissions such that they are only readable by the file owner.
This corresponds to:
- Setting the umask of the file to `600` on Unix systems.
- Setting the ACL of the file to only include the SID of the file owner (which mirrors the behavior of umask `600`) on Windows systems.

This is done specifically as a restriction rather than setting an arbitrary umask to ensure it worked across both Unix and Windows platforms.