### PR TITLE
update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default = ["libflate", "slog-kvfilter"]
 json = ["slog-json"]
 
 [dependencies]
-chrono="0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 libflate = {version = "1", optional = true}
 serde = {version = "1", features = ["derive"]}
 slog = "2"
@@ -32,7 +32,7 @@ trackable = "1"
 regex="1"
 
 [dev-dependencies]
-clap = "2"
+clap = "4"
 log = "0.4"
 serdeconv = "0.4"
 tempfile = "3"

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -3,14 +3,14 @@ extern crate slog;
 #[macro_use]
 extern crate trackable;
 
-use clap::{App, Arg};
+use clap::{Arg, Command};
 use sloggers::{Build, Config, LoggerConfig};
 
 fn main() {
-    let matches = App::new("hello")
-        .arg(Arg::with_name("CONFIG_FILE").index(1).required(true))
+    let matches = Command::new("hello")
+        .arg(Arg::new("CONFIG_FILE").index(1).required(true))
         .get_matches();
-    let config_file = matches.value_of("CONFIG_FILE").unwrap();
+    let config_file = matches.get_one::<String>("CONFIG_FILE").unwrap();
 
     let config: LoggerConfig = track_try_unwrap!(serdeconv::from_toml_file(config_file));
     let builder = track_try_unwrap!(config.try_to_builder());

--- a/src/file.rs
+++ b/src/file.rs
@@ -737,7 +737,7 @@ mod tests {
             &path_template,
             "%Y%m%d_%H%M",
             TimeZone::Utc, // Local is difficult to test, omitting :(
-            Utc.from_utc_datetime(&NaiveDateTime::from_timestamp(1537265991, 0)),
+            Utc.from_utc_datetime(&NaiveDateTime::from_timestamp_opt(1537265991, 0).unwrap()),
         );
         let expected = dir.path().join("foo_20180918_1019.log");
         assert_eq!(expected, actual);


### PR DESCRIPTION
and address RUSTSEC warnings and errors like [RUSTSEC-2020-0071](https://rustsec.org/advisories/RUSTSEC-2020-0071).
See [here](https://github.com/chronotope/chrono/issues/602#issuecomment-1075915577) for more info regarding it.
Thanks